### PR TITLE
Fix string star

### DIFF
--- a/steps/src/main/xml/steps/archive.xml
+++ b/steps/src/main/xml/steps/archive.xml
@@ -37,7 +37,7 @@
         <glossterm>implementation-defined</glossterm>.</impl>
   </para>
 
-  <section xml:id="cv.request">
+  <section xml:id="cv.manifest">
     <title>Specifying an archive manifest</title>
 
     <para>An archive manifest is represented by a <tag>c:archive</tag> root element.</para>
@@ -48,8 +48,8 @@
     </note>
     <!--<e:rng-pattern name="..."/>-->
 
-    <para>The <code>c:archive</code> root element may contain additional <glossterm>implementation-defined</glossterm>
-      attributes.</para>
+    <para><impl>The <code>c:archive</code> root element may contain additional <glossterm>implementation-defined</glossterm>
+      attributes.</impl></para>
 
     <para>All entries in the archive must be present as <tag>c:file</tag> child elements:</para>
 
@@ -102,8 +102,8 @@
       constructing the archive. For instance, an e-book in EPub format has a non-compressed entry that must be first in
       the archive. It should be possible to construct such an archive using <code>p:archive</code>.</para>
 
-    <para>The <code>c:file</code> elements may contain additional <glossterm>implementation-defined</glossterm>
-      attributes.</para>
+    <para><impl>The <code>c:file</code> elements may contain additional <glossterm>implementation-defined</glossterm>
+      attributes.</impl></para>
     <note role="editorial">
       <para>Do we need to say anything about serialization options for XML contents?</para>
       <para>Not sure whether JSON needs more specifications</para>

--- a/tools/xsl/library-to-rnc.xsl
+++ b/tools/xsl/library-to-rnc.xsl
@@ -88,6 +88,12 @@
         </xsl:message>
 	<xsl:value-of select="'xsd:string'"/>
       </xsl:when>
+      <xsl:when test="@as = 'xs:string*' or @as = 'xs:anyURI*'">
+        <!-- We have options that take list values, but you can't specify lists of strings in RELAX NG. -->
+        <!-- This is OK though because if you put the value in the option shortcut form, it's flattened -->
+        <!-- into a single string anyway. -->
+	<xsl:value-of select="replace(replace(substring-before(@as, '*'), 'xs:', 'xsd:'), '#', '')"/>
+      </xsl:when>
       <xsl:otherwise>
 	<xsl:value-of select="replace(replace(@as, 'xs:', 'xsd:'), '#', '')"/>
       </xsl:otherwise>


### PR DESCRIPTION
Steps that have options of type xs:string* and xs:uri* will no longer cause RELAX NG errors.

I fixed a couple of markup errors in the p:archive step.