### PR TITLE
attempt to improve p:archive (archive input port, manifestless creation, …)

### DIFF
--- a/src/main/schema/core30.rnc
+++ b/src/main/schema/core30.rnc
@@ -774,6 +774,14 @@ AnyElement =
    }
 
 [
+   sa:model = "anyNonXProcElement"
+]
+AnyNonXProcElement =
+   element * - (c:* | p:*) {
+      (_any.attr | text | AnyElement)*
+   }
+
+[
    sa:model = "anyNode"
 ]
 Any =
@@ -930,7 +938,7 @@ VocabData =
 VocabArchive =
    element c:archive {
       VocabEntry* &
-      AnyElement*
+      AnyNonXProcElement*
    }
 
 [

--- a/src/main/schema/core30.rnc
+++ b/src/main/schema/core30.rnc
@@ -186,7 +186,7 @@ decl.attributes = psvi-required.attr?,
 start = Library | DeclareStep
  | VocabParam | VocabParamSet | VocabResult | VocabHttpRequest
  | VocabHeader | VocabMultipart | VocabBody | VocabHttpResponse | VocabQuery
- | VocabLine | VocabData | VocabDirectory | Errors | StandardStep | ExtraStep
+ | VocabLine | VocabData | VocabDirectory | VocabArchive | Errors | StandardStep | ExtraStep
 
 # StandardStep is explicitly unspecified because this is not a complete schema
 ExtraStep = notAllowed
@@ -922,6 +922,29 @@ VocabData =
       attribute charset { text }?,
       attribute encoding { text }?,
       text
+   }
+
+[
+   sa:class = "step-vocabulary"
+]
+VocabArchive =
+   element c:archive {
+      VocabEntry* &
+      AnyElement*
+   }
+
+[
+   sa:class = "step-vocabulary"
+]
+VocabEntry =
+   element c:entry {
+      attribute name { text },
+      attribute href { xsd:anyURI }?,
+      attribute comment { text }?,
+      attribute method { text }?,
+      attribute level { text }?,
+      attribute (* - (local:* | p:* | c:*)) { text }*,
+      AnyElement*
    }
 
 # ============================================================

--- a/steps/src/main/xml/steps/archive.xml
+++ b/steps/src/main/xml/steps/archive.xml
@@ -5,24 +5,26 @@
   <title>p:archive</title>
 
   <para>The <code>p:archive</code> step outputs on its <port>result</port> port an archive (usually binary) document,
-    for instance a ZIP file. A specification of the contents of the archive must be specified in a manifest XML document
-    on the <port>manifest</port>. The contents of the archive itself can come from documents provided on the
-      <port>source</port> port, from a URI, from documents specified inline in the manifest or any combination of these.
+    for instance a ZIP file. A specification of the contents of the archive may be specified in a manifest XML document
+    on the <port>manifest</port>. The contents of the archive can come from documents provided on the
+      <port>source</port> and <port>archive</port> ports, from documents specified inline in the manifest, or from a combination of these.
     The step produces a report on the <port>report</port> port, which contains the manifest, amended with additional
     information about the archiving. </para>
 
   <p:declare-step type="p:archive">
     <p:input port="source" primary="true" content-types="*/*" sequence="true"/>
-    <p:input port="manifest" content-types="application/xml" sequence="false"/>
+    <p:input port="manifest" content-types="application/xml" sequence="true"/>
+    <p:input port="archive" content-types="application/*" sequence="true"/>
     <p:output port="result" primary="true" content-types="application/*" sequence="false"/>
     <p:output port="report" content-types="application/xml" sequence="false"/>
     <p:option name="format" as="xs:QName" required="false" select="'zip'"/>
+    <p:option name="relative-to" as="xs:anyURI" required="false"/>
     <p:option name="parameters" as="map(xs:Qname, item()*)" required="false"/>
   </p:declare-step>
 
   <para>The <code>p:archive</code> step takes the document appearing on its <port>manifest</port> port as a
     specification for an archive file. It outputs this archive on its <port>result</port> port.</para>
-
+  
   <para>The format of the archive can be specified using the <option>format</option> option. Implementations
       <rfc2119>must</rfc2119> support the <biblioref linkend="zip"/> format, specified with the value <code>zip</code>.
       <impl>It is <glossterm>implementation-defined</glossterm> what other formats are supported.</impl></para>
@@ -31,33 +33,92 @@
       of the keys and the allowed values for these keys are <glossterm>implementation-defined</glossterm>.</impl>
     <error code="C0079">It is a <glossterm>dynamic error</glossterm> if the map <option>parameters</option> contains an
       entry whose key is defined by the implementation and whose value is not valid for that key.</error></para>
+  
+  <para>For the 'zip' format, the following parameters <rfc2119>must</rfc2119> be supported:</para>
+
+  <variablelist>
+    <varlistentry>
+      <term><code>command</code></term>
+      <listitem>
+        <para>“update” | “freshen” | “create” | “delete”</para>
+        <para>If no command is given, “update” (add entries that do not exist, freshen entries whose timestamp is older
+          than the underlying resource’s) will be assumed.</para>
+        <para>“update”, “freshen” and “create” will work with or without a manifest (see below).</para>
+        <para>“update” does not require an existing archive to be submitted on the <port>archive</port> port.</para>
+        <para>“freshen” and “delete” require that exactly one zip archive is supplied on the <port>archive</port> port.</para>
+        <para>“delete” informs <code>p:archive</code> to remove the entries that are specified in the manifest by
+          the <code>c:entry/@name</code>.</para>
+        <para>If an entry that should be deleted or freshened is not found in the document on the <port>archive</port>
+          port, no error is raised and nothing is changed.</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term><code>compression-level</code></term>
+      <listitem>
+        <para>“<code>smallest</code>” | “<code>fastest</code>” | “<code>default</code>” | “<code>huffman</code>” 
+          | “<code>none</code>”</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term><code>compression-method</code></term>
+      <listitem>
+        <para>“<code>stored</code>” | “<code>deflated</code>”</para>
+      </listitem>
+    </varlistentry>
+  </variablelist>
+  
+  <para>Implementations of other archive formats <rfc2119>should</rfc2119> use the same parameter names if applicable. 
+    The value spaces for these parameters may be format-specific though. They are 
+    <glossterm>implementation-defined</glossterm>.</para>
+  
+  <para>Whether other archive formats and implementations support modifications of <port>archive</port> inputs
+  is <glossterm>implementation-defined</glossterm>.</para>
+  
+  <para><error code="C0080">It is a <glossterm>dynamic error</glossterm> if the number of documents on
+      the <port>archive</port> does not match the expected number of archive input documents for the
+      given <code>format</code> and <code>command</code>.</error></para>
+  
+  <note>
+    <para>The expected number of documents on the <port>archive</port> may be zero for formats such as gzip that do not 
+      allow manipulation of existing archives.</para>
+    <para>A hypothetical archive merging implementation, on the other hand, may accept more than one document
+    on the <port>archive</port> port.</para>
+  </note>
+  
+  <para><error code="C0081">It is a <glossterm>dynamic error</glossterm> if the content type of a document on the 
+    <port>archive</port> does not match the given archive <code>format</code>.</error></para>
+
+  <para>If no manifest entry is given for a <port>source</port> document, the step will manufacture
+    a manifest entry from the document’s <code>base-uri</code> property. If no document arrives on
+    the <port>manifest</port>, it will create a complete manifest document (see below for the
+    manifest document specification). The option <option>relative-to</option> can be used to derive
+    the entry’s <tag role="attribute">name</tag> attribute from the <port>source</port> document’s
+      <code>base-uri</code> property, which in turn will used for the entry’s <tag role="attribute"
+      >href</tag> attribute. Both the URI that is given in <option>relative-to</option> and the value of the 
+  <code>base-uri</code> property should be normalized with respect to slash deduplication, parent path
+    elimination, and drive letter case folding. The the step will remove the leading (normalized) 
+    <option>relative-to</option> option value from the <port>source</port> document’s (normalized) base URI. 
+    If there is no match, the manifest entry’s <tag role="attribute">name</tag> attribute should consist of the 
+    path part of the <port>source</port> document’s base URI, without any leading slashes.</para>
 
   <para>The <port>report</port> port outputs a copy of the manifest, optionally amended with additional attributes
     and/or elements. <impl>The semantics of any additional attributes, elements and their values are
         <glossterm>implementation-defined</glossterm>.</impl>
   </para>
 
-  <section xml:id="cv.request">
+  <section xml:id="cv.manifest">
     <title>Specifying an archive manifest</title>
 
     <para>An archive manifest is represented by a <tag>c:archive</tag> root element.</para>
 
-    <note role="editorial">
-      <para>TBD: Specify <tag>c:archive</tag> root element using schemas. Proposal:</para>
-      <programlisting><![CDATA[<c:archive> <c:file>* </c:archive>]]></programlisting>
-    </note>
-    <!--<e:rng-pattern name="..."/>-->
+    <e:rng-pattern name="VocabArchive" xml:id="cv.archive"/>
 
     <para>The <code>c:archive</code> root element may contain additional <glossterm>implementation-defined</glossterm>
       attributes.</para>
 
-    <para>All entries in the archive must be present as <tag>c:file</tag> child elements:</para>
+    <para>All entries in the archive must be present as <tag>c:entry</tag> child elements:</para>
 
-    <note role="editorial">
-      <para>TBD: Specify <tag>c:file</tag> elements using schemas. Proposal:</para>
-      <programlisting><![CDATA[<c:entry name="..." href?="..." compression-method?="..."> ...optional contents... </c:entry>]]></programlisting>
-    </note>
-    <!--<e:rng-pattern name="..."/>-->
+    <e:rng-pattern name="VocabEntry" xml:id="cv.entry"/>
 
     <para>The <code>name</code> attribute specifies the name of the entry in the archive. It <rfc2119>must</rfc2119> be
       specified as a relative path.</para>
@@ -68,17 +129,26 @@
             present and its value is not a valid <type>xs:anyURI</type>.</error></para>
       </listitem>
       <listitem>
-        <para>When the <tag>c:file</tag> elements has any child nodes, it is ignored.</para>
+        <para>When the <tag>c:entry</tag> elements has any child nodes, it is ignored.</para>
+        <note role="editorial">
+          <para>Why should the entry be ignored if it has content? Shouldn’t the entry’s content rather be ignored?</para>
+        </note>
       </listitem>
       <listitem>
         <para>The <code>p:archive</code> step checks the documents appearing on its <port>source</port> port for any
           documents with exactly the same base URI as the contents of the <code>href</code> attribute. If any such
           documents are found, the <emphasis>first</emphasis> of these is used as entry for the archive.</para>
+        <note role="editorial">
+          <para>In the interest of portability and reproducibility, shouldn’t we raise a dynamic
+            error if the same <code>href</code> attribute is used on manifest entry? If the
+            documents are, for example, taken from the <port>secondary</port> port of a
+              <code>p:xslt</code> step, the document order may be different among implementations,
+            file systems, etc.</para>
+        </note>
       </listitem>
       <listitem>
         <para>If the above doesn't apply, the value of the <code>href</code> attribute is interpreted as a URI and the
-          document is loaded from this.</para>
-
+          document is loaded from this location.</para>
         <para><error code="D0011">It is a <glossterm>dynamic error</glossterm> if the resource referenced by the
               <option>href</option> option does not exist, cannot be accessed or is not a file</error></para>
         <para> If the <option>href</option> option is relative, it is made absolute against the base URI of the
@@ -98,11 +168,11 @@
     <para>When the <code>c:file</code> element has any child nodes this is taken as the contents of the archive's entry.
       The <code>href</code> attribute is ignored in this case.</para>
 
-    <para>The <code>p:archive</code> step should strive to retain the order of the <tag>c:file</tag> elements when
-      constructing the archive. For instance, an e-book in EPub format has a non-compressed entry that must be first in
+    <para>The <code>p:archive</code> step <rfc2119>should</rfc2119> strive to retain the order of the <tag>c:entry</tag> elements when
+      constructing the archive. For instance, an e-book in EPUB format has a non-compressed entry that must be first in
       the archive. It should be possible to construct such an archive using <code>p:archive</code>.</para>
 
-    <para>The <code>c:file</code> elements may contain additional <glossterm>implementation-defined</glossterm>
+    <para>The <code>c:entry</code> elements may contain additional <glossterm>implementation-defined</glossterm>
       attributes.</para>
     <note role="editorial">
       <para>Do we need to say anything about serialization options for XML contents?</para>

--- a/steps/src/main/xml/steps/archive.xml
+++ b/steps/src/main/xml/steps/archive.xml
@@ -140,7 +140,7 @@
           documents are found, the <emphasis>first</emphasis> of these is used as entry for the archive.</para>
         <note role="editorial">
           <para>In the interest of portability and reproducibility, shouldn’t we raise a dynamic
-            error if the same <code>href</code> attribute is used on manifest entry? If the
+            error if the same <code>href</code> attribute is used on another manifest entry? If the
             documents are, for example, taken from the <port>secondary</port> port of a
               <code>p:xslt</code> step, the document order may be different among implementations,
             file systems, etc.</para>


### PR DESCRIPTION
Also provide an RNC schema for the manifest.

I renamed Erik’s `c:file` back to to `pxp:zip`’s `c:entry` so that we don’t have to differentiate between `c:file` in directory listings and `c:file` in archive entries.