### PR TITLE
Proposing json-join again

### DIFF
--- a/step-json/src/main/xml/steps/join-json.xml
+++ b/step-json/src/main/xml/steps/join-json.xml
@@ -6,15 +6,21 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          xml:id="c.join-json"
          version="5.0-extension w3c-xproc">
-<title>p:join-json</title>
+<title>p:json-join</title>
 
-<para>T.B.D.</para>
+<para>The <code>p:json-join</code> step joins a sequence of JSON documents into a single JSON document (an array).
+If the sequence on port <code>source</code> is empty, the empty sequence is returned on port <code>result</code>.</para>
 
 <p:declare-step type="p:join-json">
-  <p:input port="source"/>
-  <p:output port="result"/>
+  <p:input port="source" sequence="true" content-types="application/json application/*+json"> </p:input>
+  <p:output port="result" content-types="application/json"/>
+  <p:option name="flatten-arrays" as="xs:boolean" select="false()" />
 </p:declare-step>
 
-<para>T.B.D.</para>
+<para>If option <code>flatten-arrays</code> is <literal>false</literal>, a member in the array is created for each document in
+the sequence appearing on port<code>source</code>. Therefor the produced array with have the same number of
+members as the number of documents appearing on port <code>source</code>. However if <code>flatten-arrays</code> is
+<literal>true</literal>, for each member of an array appearing at the top level of a JSON-document 
+on port <code>source</code> a new member in the resulting array will be created.</para>
 
 </section>

--- a/step-json/src/main/xml/steps/join-json.xml
+++ b/step-json/src/main/xml/steps/join-json.xml
@@ -18,9 +18,9 @@ If the sequence on port <code>source</code> is empty, the empty sequence is retu
 </p:declare-step>
 
 <para>If option <code>flatten-arrays</code> is <literal>false</literal>, a member in the array is created for each document in
-the sequence appearing on port<code>source</code>. Therefor the produced array with have the same number of
+the sequence appearing on port<code>source</code>. Therefore the produced array with have the same number of
 members as the number of documents appearing on port <code>source</code>. However if <code>flatten-arrays</code> is
-<literal>true</literal>, for each member of an array appearing at the top level of a JSON-document 
+<literal>true</literal>, for each member of an array appearing at the top level of a JSON document 
 on port <code>source</code> a new member in the resulting array will be created.</para>
 
 </section>

--- a/step-json/src/main/xml/steps/join-json.xml
+++ b/step-json/src/main/xml/steps/join-json.xml
@@ -12,7 +12,7 @@
 If the sequence on port <code>source</code> is empty, the empty sequence is returned on port <code>result</code>.</para>
 
 <p:declare-step type="p:join-json">
-  <p:input port="source" sequence="true" content-types="application/json application/*+json"> </p:input>
+  <p:input port="source" sequence="true" content-types="json"> </p:input>
   <p:output port="result" content-types="application/json"/>
   <p:option name="flatten-arrays" as="xs:boolean" select="false()" />
 </p:declare-step>


### PR DESCRIPTION
Since we now have consensus, only to include those JSON-related steps, which can not be written in XPath, I propose this step again.
One can not write it in XPath because it relies on the order on the documents on the source port and fn:collection() does not preserve order.