### PR TITLE
Added @uri to c:file etc.

### DIFF
--- a/src/main/schema/core30.rnc
+++ b/src/main/schema/core30.rnc
@@ -818,6 +818,7 @@ VocabParamSet =
 VocabDirectory =
    element c:directory {
       attribute name { text },
+      attribute uri { text },
       ((VocabFile|VocabDirectory|VocabOther)*)
    }
 [
@@ -826,6 +827,7 @@ VocabDirectory =
 VocabFile =
    element c:file {
       attribute name { text },
+      attribute uri { text },
       content-types.attr?,
       empty
    }
@@ -835,6 +837,7 @@ VocabFile =
 VocabOther =
    element c:other {
       attribute name { text },
+      attribute uri { text },
       empty
    }
 [


### PR DESCRIPTION
Added attribute `uri`, so the complete uri (and not just the name) is included in c:file etc. returned by p:directory-list.
Could somebody please confirm this PR soon, because we need this for our London tutorial.