### PR TITLE
remove uri attribute on c:directory; correct xml:base in example

### DIFF
--- a/src/main/schema/core30.rnc
+++ b/src/main/schema/core30.rnc
@@ -818,7 +818,6 @@ VocabParamSet =
 VocabDirectory =
    element c:directory {
       attribute name { text },
-      attribute uri { xsd:anyURI },
       xmlbase.attr,
       file-info.attributes*,
       ((VocabFile|VocabDirectory|VocabOther)*)

--- a/src/main/schema/core30.rnc
+++ b/src/main/schema/core30.rnc
@@ -828,7 +828,6 @@ VocabDirectory =
 VocabFile =
    element c:file {
       attribute name { text },
-      attribute uri { xsd:anyURI },
       xmlbase.attr,
       file-info.attributes*,
       content-types.attr?,
@@ -840,7 +839,6 @@ VocabFile =
 VocabOther =
    element c:other {
       attribute name { text },
-      attribute uri { xsd:anyURI },
       xmlbase.attr,
       file-info.attributes*,
       empty

--- a/src/main/schema/core30.rnc
+++ b/src/main/schema/core30.rnc
@@ -830,7 +830,6 @@ VocabFile =
       attribute name { text },
       xmlbase.attr,
       file-info.attributes*,
-      content-types.attr?,
       empty
    }
 [

--- a/steps/src/main/xml/steps/directory-list.xml
+++ b/steps/src/main/xml/steps/directory-list.xml
@@ -78,9 +78,9 @@ one representing a regular expressions as specified in <biblioref linkend="xpath
     intermediate directories:</para>
     <literallayout>&lt;c:directory xml:base="file:///home/jane/" name="jane">
   &lt;c:directory xml:base="a/" name="a">
-    &lt;c:directory xml:base="a/a/" name="a">
-      &lt;c:directory xml:base="a/a/b/" name="b">
-        &lt;c:file xml:base="a/a/b/file.txt" name="file.txt"/>
+    &lt;c:directory xml:base="a/" name="a">
+      &lt;c:directory xml:base="b/" name="b">
+        &lt;c:file xml:base="file.txt" name="file.txt"/>
       &lt;/c:directory>
     &lt;/c:directory>
   &lt;/c:directory>


### PR DESCRIPTION
Not sure whether the change in src/main/schema/core30.rnc will immediately show in the generated syntax boxes. We might need to update the same file in the 3.0-specification repo.