### PR TITLE
Fix unescape markup

### DIFF
--- a/steps/src/main/xml/steps/unescape-markup.xml
+++ b/steps/src/main/xml/steps/unescape-markup.xml
@@ -6,9 +6,9 @@
 <title>p:unescape-markup</title>
 
 <para>The <tag>p:unescape-markup</tag> step takes the string value of
-the document element and parses the content as if it was a Unicode
+the document's child elements and parses the content as if it was a Unicode
 character stream containing serialized XML. The output consists of the
-same document element with children that result from the parse. This
+same elements with children that result from the parse. This
 is the reverse of the <tag>p:escape-markup</tag> step.</para>
 
 <p:declare-step type="p:unescape-markup">


### PR DESCRIPTION
Removed the notion of "document element", so all element childs of the document node are now unescaped.