### PR TITLE
Updated p:unarchive to decisions made in last call

### DIFF
--- a/steps/src/main/xml/steps/unarchive.xml
+++ b/steps/src/main/xml/steps/unarchive.xml
@@ -4,34 +4,48 @@
 
   <title>p:unarchive</title>
 
-  <para>The <code>p:unarchive</code> step outputs on its <port>result</port> port specific
-    entries in an archive (for instance from a zip file).</para>
+  <para>The <code>p:unarchive</code> step outputs on its <port>result</port> port specific entries
+    in an archive (for instance from a zip file).</para>
 
   <p:declare-step type="p:unarchive">
     <p:input port="source" primary="true" content-types="*/*" sequence="false"/>
     <p:output port="result" primary="true" content-types="*/*" sequence="true"/>
     <p:option name="include-filter" as="xs:string*" e:type="RegularExpression" required="false"/>
     <p:option name="exclude-filter" as="xs:string*" e:type="RegularExpression" required="false"/>
-    <p:option name="format" as="xs:QName" required="false" select="'zip'"/>
+    <p:option name="format" as="xs:QName" required="false"/>
     <p:option name="parameters" as="map(xs:Qname, item()*)" required="false"/>
   </p:declare-step>
 
-  
+  <para>The format of the archive is determined as follows:</para>
+  <itemizedlist>
+    <listitem>
+      <para>If the <option>format</option> option is specified, this determines the format of the
+        archive. Implementations <rfc2119>must</rfc2119> support the <biblioref linkend="zip"/>
+        format, specified with the value <code>zip</code>. <impl>It is
+            <glossterm>implementation-defined</glossterm> what other formats are supported.</impl>
+        <error code="C0081">It is a <glossterm>dynamic error</glossterm> if the format of the
+          archive does not match the format as specified in the <option>format</option>
+          option.</error></para>
+    </listitem>
+    <listitem>
+      <para>If no <option>format</option> option is specified or if its value is the empty sequence,
+        the archive's format will be determined by the step, using the <code>content-type</code>
+        document-property of the document on the <port>source</port> port and/or by inspecting its
+        contents. <impl>It is <glossterm>implementation-defined</glossterm> how the step determines
+          the archive's format.</impl> Implementations <rfc2119>should</rfc2119> recognize archives
+        in <biblioref linkend="zip"/> format. </para>
+    </listitem>
+  </itemizedlist>
 
-  <para>The format of the archive can be specified using the <option>format</option> option.
-    Implementations <rfc2119>must</rfc2119> support the <biblioref linkend="zip"/> format, specified
-    with the value <code>zip</code>. <impl>It is <glossterm>implementation-defined</glossterm> what
-      other formats are supported.</impl></para>
-
-  <para>The <option>parameters</option> option can be used to supply parameters to control the unarchiving.
-      <impl>The semantics of the keys and the allowed values for these keys are
+  <para>The <option>parameters</option> option can be used to supply parameters to control the
+    unarchiving. <impl>The semantics of the keys and the allowed values for these keys are
         <glossterm>implementation-defined</glossterm>.</impl>
     <error code="C0079">It is a <glossterm>dynamic error</glossterm> if the map
         <option>parameters</option> contains an entry whose key is defined by the implementation and
       whose value is not valid for that key.</error></para>
 
   <para>If present, the value of the <option>include-filter</option> or
-    <option>exclude-filter</option> option <rfc2119>must</rfc2119> be a sequence of strings, each
+      <option>exclude-filter</option> option <rfc2119>must</rfc2119> be a sequence of strings, each
     one representing a regular expressions as specified in <biblioref linkend="xpath31-functions"/>,
     section 7.61 “<literal>Regular Expression Syntax</literal>”.</para>
 
@@ -64,10 +78,11 @@
   <para>As a result: an item is included if it matches (at least) one of the
       <option>include-filter</option> values and none of the <option>exclude-filter</option>
     values.</para>
-  
-  <note role="editorial">
-    <para>What about the base URIs of these documents?</para>
-  </note>
+
+  <para>The base URI of an unarchived document appearing on the <port>result</port> port is the
+    relative path of this document as it was in the archive. For instance, the base URI of an
+    unarchived file called <code>xyz.xml</code> that resided in the <code>specs</code> subdirectory
+    in the archive will become <code>specs/xyz.xml</code>.</para>
 
   <simplesect>
     <title>Document properties</title>

--- a/steps/src/main/xml/steps/unarchive.xml
+++ b/steps/src/main/xml/steps/unarchive.xml
@@ -2,7 +2,7 @@
   xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.unarchive">
 
-  <title>p:unarchive</title>
+  <title>p:unarchive</title> 
 
   <para>The <code>p:unarchive</code> step outputs on its <port>result</port> port specific entries
     in an archive (for instance from a zip file).</para>


### PR DESCRIPTION
This implements #116 for the decisions we made in our last call about `p:unarchive` 

I made a decision about the base URI of unarchived documents which we did not discuss, might be controversial, please comment: 

>The base URI of an unarchived document appearing on the result port is the relative path of this document as it was in the archive. For instance, the base URI of an unarchived file called xyz.xml that resided in the specs subdirectory in the archive will become specs/xyz.xml.