### PR TITLE
Adding error to p:xslt

### DIFF
--- a/steps/src/main/xml/steps/xslt.xml
+++ b/steps/src/main/xml/steps/xslt.xml
@@ -41,7 +41,9 @@ to determine what version to use, including, but not limited to,
 examining the version of the stylesheet.</para>
 
 <para>The XSLT stylesheet provided on the <port>stylesheet</port> port
-is applied to the document on the <port>source</port> port. Any
+is applied to the document on the <port>source</port> port. <error code="C0093">
+It is a <glossterm>dynamic error</glossterm> if a static error occurrs during 
+the static analysis of the XSLT stylesheet.</error> Any
 parameters passed in the <option>parameters</option> option are used
 to define top-level stylesheet parameters. The primary result document
 of the transformation, if there is one, appears on the

--- a/steps/src/main/xml/steps/xslt.xml
+++ b/steps/src/main/xml/steps/xslt.xml
@@ -42,7 +42,7 @@ examining the version of the stylesheet.</para>
 
 <para>The XSLT stylesheet provided on the <port>stylesheet</port> port
 is applied to the document on the <port>source</port> port. <error code="C0093">
-It is a <glossterm>dynamic error</glossterm> if a static error occurrs during 
+It is a <glossterm>dynamic error</glossterm> if a static error occurs during 
 the static analysis of the XSLT stylesheet.</error> Any
 parameters passed in the <option>parameters</option> option are used
 to define top-level stylesheet parameters. The primary result document


### PR DESCRIPTION
Just added a catchable error code to mark that an XSLT stylesheet is not statically valid.