### PR TITLE
Add dynamic errors to the errors appendix

### DIFF
--- a/steps/src/main/xml/errors.xml
+++ b/steps/src/main/xml/errors.xml
@@ -16,10 +16,16 @@ upwards until either a <tag>p:try</tag> is encountered or the entire
 pipeline fails. In other words, outside of a <tag>p:try</tag>, step
 failure causes the entire pipeline to fail.</para>
 
-<para>The following errors can be raised by steps in this
-specification:</para>
+<para>Dynamic errors raised by steps are divided into two categories:
+dynamic errors and step errors. The distinction is largely that “step
+errors” tend to be related to a particular step or small group of
+steps (e.g., validation error) whereas the “dynamic errors” apply to
+many more steps (e.g., URI not available). There is also precedent for some
+of the error codes dating back to XProc 1.0.</para>
 
-<?step-error-list level="none"?>
+<?dynamic-error-list?>
+
+<?step-error-list?>
 
 </section>
 


### PR DESCRIPTION
Issue number 113 in the test-suite is actually caused by the fact that the steps specification does not list the dynamic errors (err:XD...) in the errors appendix.

This PR fixes that.
