### PR TITLE
Attempt to fix 183

### DIFF
--- a/step-validation/src/main/xml/specification.xml
+++ b/step-validation/src/main/xml/specification.xml
@@ -190,10 +190,9 @@ validation to the <port>source</port> document.</para>
 
 <para>If the <port>schema</port> document has an XML media type, then
 it <rfc2119>must</rfc2119> be interpreted as a RELAX NG Grammar. If
-the <port>schema</port> document has the media type
-“<literal>application/relax-ng-compact-syntax</literal>” or the media
-type has a “<literal>text</literal>” type, then it
-<rfc2119>must</rfc2119> be interpreted as a <biblioref linkend="relaxng-compact-syntax"/> document for validation.</para>
+the <port>schema</port> document has a text media type, then it
+<rfc2119>must</rfc2119> be interpreted as a 
+<biblioref linkend="relaxng-compact-syntax"/> document for validation.</para>
 
 <para>If the <option>dtd-attribute-values</option> option is
 <literal>true</literal>, then the attribute value defaulting conventions of


### PR DESCRIPTION
Attempt to fix #183 : As application/relax-ng-compact-syntax now is a text media type, we do not have to call it out here.