### PR TITLE
Fix archive steps

### DIFF
--- a/steps/src/main/xml/steps/archive-manifest.xml
+++ b/steps/src/main/xml/steps/archive-manifest.xml
@@ -8,7 +8,7 @@
     the archive appearing on its <port>source</port> port.</para>
 
   <p:declare-step type="p:archive-manifest">
-    <p:input port="source" primary="true" content-types="*/*" sequence="false"/>
+    <p:input port="source" primary="true" content-types="any" sequence="false"/>
     <p:output port="result" primary="true" content-types="application/xml" sequence="false"/>
     <p:option name="format" as="xs:QName?"/>
     <p:option name="parameters" as="map(xs:Qname, item()*)?"/>

--- a/steps/src/main/xml/steps/archive.xml
+++ b/steps/src/main/xml/steps/archive.xml
@@ -11,9 +11,9 @@
     information about the archiving.</para>
 
   <p:declare-step type="p:archive">
-    <p:input port="source" primary="true" content-types="*/*" sequence="true"/>
+    <p:input port="source" primary="true" content-types="any" sequence="true"/>
     <p:input port="manifest" content-types="application/xml" sequence="true"/>
-    <p:input port="archive" content-types="application/*" sequence="true"/>
+    <p:input port="archive" content-types="any" sequence="true"/>
     <p:output port="result" primary="true" content-types="application/*" sequence="false"/>
     <p:output port="report" content-types="application/xml" sequence="false"/>
     <p:option name="format" as="xs:QName" select="'zip'"/>

--- a/steps/src/main/xml/steps/archive.xml
+++ b/steps/src/main/xml/steps/archive.xml
@@ -14,7 +14,7 @@
     <p:input port="source" primary="true" content-types="any" sequence="true"/>
     <p:input port="manifest" content-types="application/xml" sequence="true"/>
     <p:input port="archive" content-types="any" sequence="true"/>
-    <p:output port="result" primary="true" content-types="application/*" sequence="false"/>
+    <p:output port="result" primary="true" content-types="any" sequence="false"/>
     <p:output port="report" content-types="application/xml" sequence="false"/>
     <p:option name="format" as="xs:QName" select="'zip'"/>
     <p:option name="relative-to" as="xs:anyURI?"/>

--- a/steps/src/main/xml/steps/unarchive.xml
+++ b/steps/src/main/xml/steps/unarchive.xml
@@ -8,8 +8,8 @@
     in an archive (for instance from a zip file).</para>
 
   <p:declare-step type="p:unarchive">
-    <p:input port="source" primary="true" content-types="*/*" sequence="false"/>
-    <p:output port="result" primary="true" content-types="*/*" sequence="true"/>
+    <p:input port="source" primary="true" content-types="any" sequence="false"/>
+    <p:output port="result" primary="true" content-types="any" sequence="true"/>
     <p:option name="include-filter" as="xs:string*" e:type="RegularExpression"/>
     <p:option name="exclude-filter" as="xs:string*" e:type="RegularExpression"/>
     <p:option name="format" as="xs:QName?"/>


### PR DESCRIPTION
I do not think this is controversial:

- Replaced "\*/*" on ports with "any"
- Harmonized sequence type of archive ports: It was "application/\*" on p:archive, but "\*/*" on the two other steps. Now it is "any" on all.