### PR TITLE
Just added note that supported xslt versions are implementation defined.

### DIFF
--- a/steps/src/main/xml/steps/xslt.xml
+++ b/steps/src/main/xml/steps/xslt.xml
@@ -23,7 +23,8 @@
       <glossterm>dynamic error</glossterm> if the specified xslt version is not available.</error> If
     the step does not specify a version, the implementation may use any version it has available and
     may use any means to determine what version to use, including, but not limited to, examining the
-    version of the stylesheet.</para>
+    version of the stylesheet. <impl>It is <glossterm>implementation defined</glossterm> which XSLT
+    version(s) is/are supported.</impl></para>
   <para>The XSLT stylesheet provided on the <port>stylesheet</port> port is invoked. <error
     code="C0093"> It is a <glossterm>dynamic error</glossterm> if a static error occurs during the
     static analysis of the XSLT stylesheet.</error> Any parameters passed in the


### PR DESCRIPTION
This was obvious from the prose, but the `impl` element was missing. Fixed this to make sure, it goes to the list of implementation defined features.