### PR TITLE
Additional error condition for #114

### DIFF
--- a/steps/src/main/xml/steps/compress.xml
+++ b/steps/src/main/xml/steps/compress.xml
@@ -4,9 +4,8 @@
 
   <title>p:compress</title>
 
-  <para>The <tag>p:compress</tag> step serializes the document appearing on its
-      <port>source</port> port and outputs a compressed version of this on its <port>result</port>
-    port.</para>
+  <para>The <tag>p:compress</tag> step serializes the document appearing on its <port>source</port>
+    port and outputs a compressed version of this on its <port>result</port> port.</para>
 
   <p:declare-step type="p:compress">
     <p:input port="source" primary="true" content-types="any" sequence="false"/>
@@ -23,13 +22,15 @@
   <para>The <tag>p:compress</tag> step has the following options:</para>
   <variablelist>
     <varlistentry>
-      <term><option>format</option></term> 
+      <term><option>format</option></term>
       <listitem>
-        <para>The format of the compression can be specified using the <option>format</option> option.
-          Implementations <rfc2119>must</rfc2119> support the <biblioref linkend="gzip"/> format,
-          specified with the value <code>gzip</code>. <impl>It is
-            <glossterm>implementation-defined</glossterm> what other formats are
-            supported.</impl></para>
+        <para>The format of the compression can be specified using the <option>format</option>
+          option. Implementations <rfc2119>must</rfc2119> support the <biblioref linkend="gzip"/>
+          format, specified with the value <code>gzip</code>. <impl>It is
+              <glossterm>implementation-defined</glossterm> what other formats are supported.</impl>
+          <error code="C0202">It is a <glossterm>dynamic error</glossterm> if the compression
+              format cannot be understood, determined and/or processed.</error>
+        </para>
       </listitem>
     </varlistentry>
     <varlistentry>

--- a/steps/src/main/xml/steps/uncompress.xml
+++ b/steps/src/main/xml/steps/uncompress.xml
@@ -25,7 +25,8 @@
             <glossterm>implementation-defined</glossterm> what other formats are supported.</impl>
         <error code="C0200">It is a <glossterm>dynamic error</glossterm> if the compression format
           does not match the format as specified in the <option>format</option>
-        option.</error></para>
+          option.</error> <error code="C0202">It is a <glossterm>dynamic error</glossterm> if the compression
+            format cannot be understood, determined and/or processed.</error></para>
     </listitem>
     <listitem>
       <para>If no <option>format</option> option is specified or its value is the empty sequence,


### PR DESCRIPTION
Added an additional error message for when `p:compress` and `p:uncompress` do not understand or cannot determine the compression format.