### PR TITLE
Attempt to fix 180

### DIFF
--- a/steps/src/main/xml/specification.xml
+++ b/steps/src/main/xml/specification.xml
@@ -186,6 +186,7 @@ linkend="rfc2119"/>.</para>
 <xi:include href="steps/label-elements.xml"/>
 <xi:include href="steps/load.xml"/>
 <xi:include href="steps/json-join.xml"/>
+<xi:include href="steps/json-merge.xml" />
 <xi:include href="steps/make-absolute-uris.xml"/>
 <xi:include href="steps/namespace-rename.xml"/>
 <xi:include href="steps/pack.xml"/>

--- a/steps/src/main/xml/steps/json-merge.xml
+++ b/steps/src/main/xml/steps/json-merge.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xml:id="c.json-merge"
+         version="5.0-extension w3c-xproc">
+<title>p:json-merge</title>
+
+<para>The <tag>p:json-merge</tag> step merges the sequence of appearing
+on port <port>source</port> into a single JSON object appearing on port
+<port>result</port>. If the sequence on
+port <port>source</port> is empty, the empty sequence is returned on
+port <port>result</port>.</para>
+
+<p:declare-step type="p:json-merge">
+  <p:input port="source" sequence="true" content-types="any"> </p:input>
+  <p:output port="result" content-types="application/json"/>
+  <p:option name="duplicates" as="xs:token" values="('reject', 'use-first', 'use-last', 'use-any', 'combine')" select="'use-first'"/>
+  <p:option name="key" as="xs:string" select="'concat(&#34;_&#34;,$p:index)'" e:type="XPathExpression"/>
+</p:declare-step>
+
+<para>The step inspects the documents on port <port>source</port> in turn to create the resulting
+  map:</para>
+<itemizedlist>
+  <listitem>
+    <para>If the document under inspection is a JSON document representing a map,
+    all key-value pairs are copied into the result map unless this map already contains
+    an entry with the given key. In this case the value of option <option>duplicates</option>
+    determines the policy for handling duplicate keys as specified for function <code>map:merge</code>
+      in <biblioref linkend="xpath31-functions"/>.  
+      <error code="C0106">It is a <glossterm>dynamic error</glossterm> if duplicate keys are encountered and 
+      option <option>duplicates</option> has value “<literal>reject</literal>”.</error></para>
+  </listitem>
+  <listitem>
+    <para>For every other type of JSON document, for XML documents, HTML documents, or text documents a
+    new key-value pair is created and put into the resulting map. The key is created by evaluating
+    the XPath expression in option <option>key</option> with the inspected document as context item. Duplicate
+    keys are handled as described above. The XDM representation of the inspected document is taken as value of
+    the key-value pair.</para>
+  </listitem>
+  <listitem>
+    <para><impl>It is <glossterm>implementation defined</glossterm> if <code>p:json-merge</code> is
+    able to process document types not mentioned yet, i.e. types of binary documents.</impl> If a processor
+    supports a given type of documents, the key-value pair is created as described above. <error code="C0107">
+    It is a <glossterm>dynamic error</glossterm> if a document of a not supported document type appears on 
+      port <port>source</port> of <code>p:json-merge</code>.</error>
+    </para>
+  </listitem>
+</itemizedlist> 
+  <para>An implementation must bind the variable “<code>p:index</code>” in the static context of 
+    each evaluation of the XPath expression to the position of the document in the sequence 
+    of documents on port <port>source</port>, starting with “<literal>1</literal>”.
+    </para>
+</section>


### PR DESCRIPTION
Attempt to fix #180 
New step p:json-merge. As @ndw observed, this can't be done with XPath because it depends on the order of documents on port `source`. (Remember collection() does not preserve order.)