### PR TITLE
Id fix on namespace delete

### DIFF
--- a/steps/src/main/xml/steps/namespace-delete.xml
+++ b/steps/src/main/xml/steps/namespace-delete.xml
@@ -2,7 +2,7 @@
       xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" 
       xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" 
       xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" 
-      xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.sink">
+      xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.namespace-delete">
 <title>p:namespace-delete</title>
 
 <para>The <tag>p:namespace-delete</tag> step deletes all of the namespaces identified by the specified 


### PR DESCRIPTION
This is a (hopefully) totally uncontroversial PR: There was an error in the id of the namespace-delete step (it was called c.sink and this must be c.namespace-delete).

My book pipelines failed over this so therefore I noticed.