### PR TITLE
#239 provide defaults for non-primary input ports

### DIFF
--- a/steps/src/main/xml/steps/archive.xml
+++ b/steps/src/main/xml/steps/archive.xml
@@ -12,8 +12,12 @@
 
   <p:declare-step type="p:archive">
     <p:input port="source" primary="true" content-types="any" sequence="true"/>
-    <p:input port="manifest" content-types="application/xml" sequence="true"/>
-    <p:input port="archive" content-types="any" sequence="true"/>
+    <p:input port="manifest" content-types="application/xml" sequence="true">
+      <p:empty/>
+    </p:input>
+    <p:input port="archive" content-types="any" sequence="true">
+      <p:empty/>
+    </p:input>
     <p:output port="result" primary="true" content-types="any" sequence="false"/>
     <p:output port="report" content-types="application/xml" sequence="false"/>
     <p:option name="format" as="xs:QName" select="'zip'"/>
@@ -50,6 +54,7 @@
           <error code="C0100">It is a <glossterm>dynamic error</glossterm> if the document on port
           <port>report</port> does not conform to the given schema.</error>
         </para>
+        <para>The default input for this port is the empty sequence.</para>
       </listitem>
     </varlistentry>
     <varlistentry>
@@ -64,6 +69,7 @@
             <port>archive</port> port. <error code="C0081">It is a <glossterm>dynamic
               error</glossterm> if the format of the archive does not match the format as specified 
               in <option>format</option> option.</error></para>
+        <para>The default input for this port is the empty sequence.</para>
       </listitem>
     </varlistentry>
   </variablelist>


### PR DESCRIPTION
Defaults for the non-primary input ports of `p:archive`. See #239