### PR TITLE
Infrastructure upgrades

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     classpath group: 'org.docbook', name: 'docbook-schemas', version: '5.1-1'
     classpath group: 'com.xmlcalabash', name: 'xmlcalabash1-print', version: '1.1.5'
     classpath group: 'com.xmlcalabash', name: 'xmlcalabash1-gradle', version: '1.3.5'
-    classpath group: 'com.xmlcalabash', name: 'xmlcalabash', version: '1.1.27-99'
+    classpath group: 'com.xmlcalabash', name: 'xmlcalabash', version: '1.1.29-99'
     classpath group: 'org.xmlresolver', name: 'xmlresolver', version: '1.0.1'
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 docbookXsltBaseUri=https://cdn.docbook.org
-docbookXsltVersion=2.3.9
+docbookXsltVersion=2.4.2
 xprocTocUri=https://spec.xproc.org/master/head/etc/xproc/toc.xml
 xprocToc=xproc_toc.xml
 schemaBaseUri=https://spec.xproc.org/master/head/etc

--- a/tools/xpl/formatspec.xpl
+++ b/tools/xpl/formatspec.xpl
@@ -17,7 +17,7 @@
 <p:option name="diff" select="''"/>
 <p:option name="specid" select="''"/>
 
-<p:import href="https://cdn.docbook.org/release/latest/xslt/base/pipelines/docbook.xpl"/>
+<p:import href="https://cdn.docbook.org/release/xsl20/current/xslt/base/pipelines/docbook.xpl"/>
 
 <p:declare-step type="cx:message">
   <p:input port="source" sequence="true"/>

--- a/tools/xsl/docbook.xsl
+++ b/tools/xsl/docbook.xsl
@@ -12,7 +12,7 @@
 		exclude-result-prefixes="f h db m t xlink xs tp"
                 version="2.0">
 
-<xsl:import href="https://cdn.docbook.org/release/latest/xslt/base/html/final-pass.xsl"/>
+<xsl:import href="https://cdn.docbook.org/release/xsl20/current/xslt/base/html/final-pass.xsl"/>
 
 <xsl:param name="js-navigation" select="false()"/>
 

--- a/tools/xsl/xprocns.xsl
+++ b/tools/xsl/xprocns.xsl
@@ -85,7 +85,24 @@
       <xsl:call-template name="doAttr"/>
     </xsl:for-each>
 
-    <code>/&gt;</code>
+    <xsl:choose>
+      <xsl:when test="self::p:input and p:*">
+        <xsl:if test="count(p:*) gt 1 or not(p:empty)">
+          <xsl:message terminate="yes">Only p:empty is supported as a default!</xsl:message>
+        </xsl:if>
+        <code>&gt;</code>
+        <br/>
+        <xsl:text>&#160;&#160;&#160;&#160;&#160;</xsl:text>
+        <xsl:text>&#160;&#160;&#160;&#160;&#160;</xsl:text>
+        <code>&lt;p:empty/&gt;</code>
+        <br/>
+        <xsl:text>&#160;&#160;&#160;&#160;&#160;</xsl:text>
+        <code>&lt;/p:input&gt;</code>
+      </xsl:when>
+      <xsl:otherwise>
+        <code>/&gt;</code>
+      </xsl:otherwise>
+    </xsl:choose>
 
     <xsl:if test="self::p:option">
       <xsl:variable name="lengths" as="xs:integer+">


### PR DESCRIPTION
1. Bump the versions of XML Calabash and the DocBook stylesheets
2. Support `p:empty` as a default input in step declarations.
