### PR TITLE
Attempt to resolve issue 251

### DIFF
--- a/steps/src/main/xml/references.xml
+++ b/steps/src/main/xml/references.xml
@@ -20,6 +20,7 @@
     <bibliomixed xml:id="rfc2119"/>
     <bibliomixed xml:id="rfc2616"/>
     <bibliomixed xml:id="rfc2617"/>
+    <bibliomixed xml:id="rfc3986"/>
     <bibliomixed xml:id="unicodetr17"/>
     <bibliomixed xml:id="tidy"/>
     <bibliomixed xml:id="tagsoup"/>

--- a/steps/src/main/xml/steps/archive-manifest.xml
+++ b/steps/src/main/xml/steps/archive-manifest.xml
@@ -51,19 +51,19 @@
       whose value is not valid for that key.</error></para>
 
   <para>The <option>relative-to</option> option, when present, is used in creating the value of the
-    manifest's <code>c:entry/@href</code> attribute.</para>
-  <para>The value provided for the <option>relative-to</option> option will before use always be
-    normalized using the <function>p:urify()</function> function. After this normalization its value
-      <rfc2119>must</rfc2119> be an absolute URI. </para>
-  <para></para>
+    manifest's <code>c:entry/@href</code> attribute. <error code="D0064">It is a <glossterm>dynamic
+        error</glossterm> if the option is not a valid URI according to <biblioref linkend="rfc3986"
+      />.</error> If the option is relative, it is made absolute against the base URI of the element
+    on which it is specified (<tag>p:with-option</tag> or the step in case of a syntactic shortcut
+    value).</para>
 
   <para>The generated manifest has the format as described in <xref linkend="cv.archive-manifest"/>.
     Implementations <rfc2119>must</rfc2119> supply an <tag>c:entry</tag> element and its
       <code>name</code> attribute for every entry in the archive. The value of the generated
-    manifest's <code>c:entry/@href</code> attribute will de determined the same as a base URI
-    of an unarchived document by <xref linkend="c.unarchive"/>. <impl>Additional information
-      provided for entries in <tag>p:archive-manifest</tag> is
-        <glossterm>implementation-defined</glossterm>.</impl></para>
+    manifest's <code>c:entry/@href</code> attribute will de determined the same as a base URI of an
+    unarchived document by <xref linkend="c.unarchive"/>. <impl>Additional information provided for
+      entries in <tag>p:archive-manifest</tag> is
+      <glossterm>implementation-defined</glossterm>.</impl></para>
 
   <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 

--- a/steps/src/main/xml/steps/archive-manifest.xml
+++ b/steps/src/main/xml/steps/archive-manifest.xml
@@ -60,10 +60,10 @@
   <para>The generated manifest has the format as described in <xref linkend="cv.archive-manifest"/>.
     Implementations <rfc2119>must</rfc2119> supply an <tag>c:entry</tag> element and its
       <code>name</code> attribute for every entry in the archive. The value of the generated
-    manifest's <code>c:entry/@href</code> attribute will de determined the same as a base URI of an
-    unarchived document by <xref linkend="c.unarchive"/>. <impl>Additional information provided for
-      entries in <tag>p:archive-manifest</tag> is
-      <glossterm>implementation-defined</glossterm>.</impl></para>
+    manifest's <code>c:entry/@href</code> attribute will be determined in the same way as a base URI
+    of an unarchived document by <xref linkend="c.unarchive"/>. <impl>Additional information
+      provided for entries in <tag>p:archive-manifest</tag> is
+        <glossterm>implementation-defined</glossterm>.</impl></para>
 
   <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 

--- a/steps/src/main/xml/steps/archive-manifest.xml
+++ b/steps/src/main/xml/steps/archive-manifest.xml
@@ -54,12 +54,7 @@
     manifest's <code>c:entry/@href</code> attribute.</para>
   <para>The value provided for the <option>relative-to</option> option will before use always be
     normalized using the <function>p:urify()</function> function. After this normalization its value
-      <rfc2119>must</rfc2119> be an absolute URI. <error code="D0064">It is a <glossterm>dynamic
-        error</glossterm> if the <option>relative-to</option> option is present and its value is not
-      a valid <type>xs:anyURI</type>. </error>
-    <error code="D0074">It is a <glossterm>dynamic error</glossterm> to provide a value for the
-        <option>relative-to</option> option that, after normalization by the
-        <function>p:urify()</function> function, is not an absolute URI.</error></para>
+      <rfc2119>must</rfc2119> be an absolute URI. </para>
   <para></para>
 
   <para>The generated manifest has the format as described in <xref linkend="cv.archive-manifest"/>.

--- a/steps/src/main/xml/steps/archive-manifest.xml
+++ b/steps/src/main/xml/steps/archive-manifest.xml
@@ -12,6 +12,7 @@
     <p:output port="result" primary="true" content-types="application/xml" sequence="false"/>
     <p:option name="format" as="xs:QName?"/>
     <p:option name="parameters" as="map(xs:Qname, item()*)?"/>
+    <p:option name="relative-to" as="xs:anyURI?"/>
   </p:declare-step>
 
   <para>The <code>p:archive-manifest</code> step inspects the archive appearing on its
@@ -24,8 +25,8 @@
       <para>If the <option>format</option> option is specified, this determines the format of the
         archive. Implementations <rfc2119>must</rfc2119> support the <biblioref linkend="zip"/>
         format, specified with the value <code>zip</code>. <impl>It is
-            <glossterm>implementation-defined</glossterm> what other formats are
-        supported.</impl> <error code="C0081">It is a <glossterm>dynamic error</glossterm> if the format of the
+            <glossterm>implementation-defined</glossterm> what other formats are supported.</impl>
+        <error code="C0081">It is a <glossterm>dynamic error</glossterm> if the format of the
           archive does not match the format as specified in the <option>format</option>
           option.</error></para>
     </listitem>
@@ -38,9 +39,9 @@
         in <biblioref linkend="zip"/> format. </para>
     </listitem>
   </itemizedlist>
-  
+
   <para><error code="C0085">It is a <glossterm>dynamic error</glossterm> if the format of the
-    archive cannot be understood, determined and/or processed.</error></para>
+      archive cannot be understood, determined and/or processed.</error></para>
 
   <para>The <option>parameters</option> option can be used to supply parameters to control the
     archive manifest generation. <impl>The semantics of the keys and the allowed values for these
@@ -49,11 +50,25 @@
         <option>parameters</option> contains an entry whose key is defined by the implementation and
       whose value is not valid for that key.</error></para>
 
+  <para>The <option>relative-to</option> option, when present, is used in creating the value of the
+    manifest's <code>c:entry/@href</code> attribute.</para>
+  <para>The value provided for the <option>relative-to</option> option will before use always be
+    normalized using the <function>p:urify()</function> function. After this normalization its value
+      <rfc2119>must</rfc2119> be an absolute URI. <error code="D0064">It is a <glossterm>dynamic
+        error</glossterm> if the <option>relative-to</option> option is present and its value is not
+      a valid <type>xs:anyURI</type>. </error>
+    <error code="D0074">It is a <glossterm>dynamic error</glossterm> to provide a value for the
+        <option>relative-to</option> option that, after normalization by the
+        <function>p:urify()</function> function, is not an absolute URI.</error></para>
+  <para></para>
+
   <para>The generated manifest has the format as described in <xref linkend="cv.archive-manifest"/>.
     Implementations <rfc2119>must</rfc2119> supply an <tag>c:entry</tag> element and its
-      <code>name</code> attribute for every entry in the archive. <impl>Additional information
-provided for entries in <tag>p:archive-manifest</tag>
-    is <glossterm>implementation-defined</glossterm>.</impl></para>
+      <code>name</code> attribute for every entry in the archive. The value of the generated
+    manifest's <code>c:entry/@href</code> attribute will de determined the same as a base URI
+    of an unarchived document by <xref linkend="c.unarchive"/>. <impl>Additional information
+      provided for entries in <tag>p:archive-manifest</tag> is
+        <glossterm>implementation-defined</glossterm>.</impl></para>
 
   <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 

--- a/steps/src/main/xml/steps/archive.xml
+++ b/steps/src/main/xml/steps/archive.xml
@@ -126,6 +126,14 @@
         <para>The <option>relative-to</option> option is used in creating a manifest when no
           manifest is provided on the <port>manifest</port> port. See <xref
             linkend="cv.archive-manifest"/>.</para>
+        <para>The value provided for the <option>relative-to</option> option will before use always
+          be normalized using the <function>p:urify()</function> function. After this normalization
+          its value <rfc2119>must</rfc2119> be an absolute URI. <error code="D0064">It is a
+              <glossterm>dynamic error</glossterm> if the <option>relative-to</option> option is
+            present and its value is not a valid <type>xs:anyURI</type>. </error>
+          <error code="D0074">It is a <glossterm>dynamic error</glossterm> to provide a value for
+            the <option>relative-to</option> option that, after normalization by the
+              <function>p:urify()</function> function, is not an absolute URI.</error></para>
       </listitem>
     </varlistentry>
   </variablelist>
@@ -177,29 +185,34 @@
             <rfc2119>must</rfc2119> be specified as a relative path.</para>
       </listitem>
       <listitem>
-        <para>The <code>href</code> attribute is interpreted as follows:</para>
+        <para>The <code>href</code> attribute will before use always be normalized by the
+            <function>p:urify()</function> function. It is interpreted as follows:</para>
         <itemizedlist>
           <listitem>
             <para><error code="D0064">It is a <glossterm>dynamic error</glossterm> if the
-                  <option>c:entry/@href</option> attribute in a <code>p:archive</code> step manifest
-                is present and its value is not a valid <type>xs:anyURI</type>.</error></para>
+                  <code>c:entry/@href</code> attribute in a <code>p:archive</code> step manifest is
+                present and its value is not a valid <type>xs:anyURI</type>.</error>
+              <error code="D0074">It is a <glossterm>dynamic error</glossterm> to provide a value
+                for the <code>c:entry/@href</code> attribute in a <code>p:archive</code> step
+                manifest that, after normalization by the <function>p:urify()</function> function, is
+                not an absolute URI.</error></para>
           </listitem>
           <listitem>
             <para>The <code>p:archive</code> step checks the documents appearing on its
                 <port>source</port> port for any documents with exactly the same base URI as the
-              contents of the <code>href</code> attribute. If any such document is found, this is
-              used as entry for the archive. To store these documents in the archive they must be
-              serialized. The <code>serialization</code> document property can be used to provide
-              serialization properties.</para>
+              value of the normalized <code>href</code> attribute. If any such document is found,
+              this is used as entry for the archive. To store these documents in the archive they
+              must be serialized. The <code>serialization</code> document property can be used to
+              provide serialization properties.</para>
           </listitem>
           <listitem>
-            <para>If the above doesn't apply, the value of the <code>href</code> attribute is
-              interpreted as a URI and the document is loaded from this location. <error
-                code="D0011">It is a <glossterm>dynamic error</glossterm> if the resource referenced
-                by the <option>href</option> option does not exist, cannot be accessed or is not a
-                file</error> If the <option>href</option> option is relative, it is made absolute
-              against the base URI of the manifest. These documents are stored in the archive "as
-              is". No parsing/serialization takes place.</para>
+            <para>If the above doesn't apply, the value of the normalized <code>href</code>
+              attribute is interpreted as a URI and the document is loaded from this location.
+                <error code="D0011">It is a <glossterm>dynamic error</glossterm> if the resource
+                referenced by the <option>href</option> option does not exist, cannot be accessed or
+                is not a file.</error> If the <option>href</option> option is relative, it is made
+              absolute against the base URI of the manifest. These documents are stored in the
+              archive "as is". No parsing/serialization takes place.</para>
           </listitem>
 
         </itemizedlist>
@@ -234,13 +247,11 @@
     <para>The option <option>relative-to</option> can be used to derive the entry’s <tag
         role="attribute">name</tag> attribute from the <port>source</port> document’s
         <code>base-uri</code> property, which in turn will be used for the entry’s <tag
-        role="attribute">href</tag> attribute. Both the URI that is given in
-        <option>relative-to</option> and the value of the <code>base-uri</code> property should be
-      normalized with respect to slash deduplication, parent path elimination, and drive letter case
-      folding. The step will remove the leading (normalized) <option>relative-to</option> option
-      value from the <port>source</port> document’s (normalized) base URI. If there is no match, the
-      manifest entry’s <tag role="attribute">name</tag> attribute will consist of the path part of
-      the <port>source</port> document’s base URI, without any leading slashes.</para>
+        role="attribute">href</tag> attribute. The step will remove the leading (normalized)
+        <option>relative-to</option> option's value from the <port>source</port> document’s
+      (normalized) base URI. If there is no match, the manifest entry’s <tag role="attribute"
+        >name</tag> attribute will consist of the path part of the <port>source</port> document’s
+      base URI, without any leading protocol specifier and slashes.</para>
   </section>
 
   <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->

--- a/steps/src/main/xml/steps/archive.xml
+++ b/steps/src/main/xml/steps/archive.xml
@@ -7,7 +7,7 @@
   <para>The <code>p:archive</code> step outputs on its <port>result</port> port an archive (usually
     binary) document, for instance a ZIP file. A specification of the contents of the archive may be
     specified in a manifest XML document on the <port>manifest</port> port. The step produces a
-    report on the <port>report</port>  port, which contains the manifest, amended with additional
+    report on the <port>report</port> port, which contains the manifest, amended with additional
     information about the archiving.</para>
 
   <p:declare-step type="p:archive">
@@ -50,12 +50,12 @@
       <listitem>
         <para>The <port>manifest</port> port can receive a manifest document that tells the step how
           to construct the archive. If no manifest document is provided on this port, a default
-          manifest is constructed automatically. See <xref linkend="cv.archive-manifest"/>. 
-          <error code="C0100">It is a <glossterm>dynamic error</glossterm> if the document on port
-          <port>manifest</port> does not conform to the given schema.</error>
+          manifest is constructed automatically. See <xref linkend="cv.archive-manifest"/>. <error
+            code="C0100">It is a <glossterm>dynamic error</glossterm> if the document on port
+              <port>manifest</port> does not conform to the given schema.</error>
         </para>
-        <para><error code="C0112">It is a <glossterm>dynamic error</glossterm> if more than one document
-        appears on the port <port>manifest</port>.</error></para>
+        <para><error code="C0112">It is a <glossterm>dynamic error</glossterm> if more than one
+            document appears on the port <port>manifest</port>.</error></para>
         <para>The default input for this port is the empty sequence.</para>
       </listitem>
     </varlistentry>
@@ -69,8 +69,8 @@
               <glossterm>implementation-defined</glossterm>.</impl> For instance an implementation
           that supports archive merging may accept more than one document on the
             <port>archive</port> port. <error code="C0081">It is a <glossterm>dynamic
-              error</glossterm> if the format of the archive does not match the format as specified 
-              in <option>format</option> option.</error></para>
+              error</glossterm> if the format of the archive does not match the format as specified
+            in <option>format</option> option.</error></para>
         <para>The default input for this port is the empty sequence.</para>
       </listitem>
     </varlistentry>
@@ -124,25 +124,25 @@
       <term><option>relative-to</option></term>
       <listitem>
         <para>The <option>relative-to</option> option is used in creating a manifest when no
-          manifest is provided on the <port>manifest</port> port. See <xref
-            linkend="cv.archive-manifest"/>. The value provided for the <option>relative-to</option>
-          option will before use always be normalized using the <function>p:urify()</function>
-          function. After this normalization its value <rfc2119>must</rfc2119> be an absolute URI.
-        </para>
+          manifest is provided on the <port>manifest</port> port. <error code="D0064">It is a
+              <glossterm>dynamic error</glossterm> if the option is not a valid URI according to
+              <biblioref linkend="rfc3986"/>.</error> If the option is relative, it is made absolute
+          against the base URI of the element on which it is specified (<tag>p:with-option</tag> or
+          the step in case of a syntactic shortcut value).</para>
       </listitem>
     </varlistentry>
   </variablelist>
-  
+
   <para>The format of the archive is determined as follows:</para>
   <itemizedlist>
     <listitem>
       <para>If the <option>format</option> option is specified, this determines the format of the
         archive. Implementations <rfc2119>must</rfc2119> support the <biblioref linkend="zip"/>
         format, specified with the value <code>zip</code>. <impl>It is
-          <glossterm>implementation-defined</glossterm> what other formats are
-          supported.</impl> <error code="C0081">It is a <glossterm>dynamic error</glossterm> if the format of the
-            archive does not match the format as specified in the <option>format</option>
-            option.</error></para>
+            <glossterm>implementation-defined</glossterm> what other formats are supported.</impl>
+        <error code="C0081">It is a <glossterm>dynamic error</glossterm> if the format of the
+          archive does not match the format as specified in the <option>format</option>
+          option.</error></para>
     </listitem>
     <listitem>
       <para>If no <option>format</option> option is specified or if its value is the empty sequence,
@@ -153,9 +153,9 @@
         in <biblioref linkend="zip"/> format. </para>
     </listitem>
   </itemizedlist>
-  
+
   <para><error code="C0085">It is a <glossterm>dynamic error</glossterm> if the format of the
-    archive cannot be understood, determined and/or processed.</error></para>
+      archive cannot be understood, determined and/or processed.</error></para>
 
   <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 
@@ -180,25 +180,25 @@
             <rfc2119>must</rfc2119> be specified as a relative path.</para>
       </listitem>
       <listitem>
-        <para>The <code>href</code> attribute will before use always be normalized by the
-            <function>p:urify()</function> function. It is interpreted as follows:</para>
+        <para>The <code>href</code> attribute must be a valid URI according to
+          <biblioref linkend="rfc3986"/>. If its value is relative, it is made absolute
+          against the base URI of the manifest. Its is interpreted as follows:</para>
         <itemizedlist>
           <listitem>
             <para>The <code>p:archive</code> step checks the documents appearing on its
                 <port>source</port> port for any documents with exactly the same base URI as the
-              value of the normalized <code>href</code> attribute. If any such document is found,
+              value of the (made absolute) <code>href</code> attribute. If any such document is found,
               this is used as entry for the archive. To store these documents in the archive they
               must be serialized. The <code>serialization</code> document property can be used to
               provide serialization properties.</para>
           </listitem>
           <listitem>
-            <para>If the above doesn't apply, the value of the normalized <code>href</code>
+            <para>If the above doesn't apply, the value of the (made absolute) <code>href</code>
               attribute is interpreted as a URI and the document is loaded from this location.
                 <error code="D0011">It is a <glossterm>dynamic error</glossterm> if the resource
                 referenced by the <option>href</option> option does not exist, cannot be accessed or
-                is not a file.</error> If the <option>href</option> option is relative, it is made
-              absolute against the base URI of the manifest. These documents are stored in the
-              archive "as is". No parsing/serialization takes place.</para>
+                is not a file.</error> These documents are stored in the archive "as is". No
+              parsing/serialization takes place.</para>
           </listitem>
 
         </itemizedlist>
@@ -229,15 +229,19 @@
     <para>If no manifest entry is provided for a document appearing on the <port>source</port> port,
       the step will manufacture a manifest entry from the document’s <code>base-uri</code> property.
       If no document arrives on the <port>manifest</port> port, it will create a complete manifest
-      document.</para>
-    <para>The option <option>relative-to</option> can be used to derive the entry’s <tag
+      document. The option <option>relative-to</option> can be used to derive the entry’s <tag
         role="attribute">name</tag> attribute from the <port>source</port> document’s
         <code>base-uri</code> property, which in turn will be used for the entry’s <tag
-        role="attribute">href</tag> attribute. The step will remove the leading (normalized)
-        <option>relative-to</option> option's value from the <port>source</port> document’s
-      (normalized) base URI. If there is no match, the manifest entry’s <tag role="attribute"
-        >name</tag> attribute will consist of the path part of the <port>source</port> document’s
-      base URI, without any leading protocol specifier and slashes.</para>
+        role="attribute">href</tag> attribute. First the step will make the value of the
+        <option>relative-to</option> absolute as specified above. Then it will remove the leading
+        <option>relative-to</option> option's value from the <port>source</port> document’s base
+      URI. If there is no match, the manifest entry’s <tag role="attribute">name</tag> attribute
+      will consist of the path part of the <port>source</port> document’s base URI, without any
+      leading protocol specifier and slashes.</para>
+    
+    <para>
+      <error code="C0118">It is a <glossterm>dynamic error</glossterm> if an archive manifest is
+        invalid according to the specification.</error></para>
   </section>
 
   <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -267,7 +271,7 @@
                   specified, zero or exactly one document in ZIP format can appear on the
                     <port>archive</port> port. If there is no document on the <port>archive</port>
                   port, an empty ZIP archive is assumed.</para>
-                <para>The contents of the manifest (either provided or (partially) constructed, see
+                <para>The contents of the manifest (either provided or automatically constructed, see
                     <xref linkend="cv.archive-manifest"/>) is held against the entries in the ZIP
                   file provided on the <port>archive</port> port: </para>
                 <itemizedlist>
@@ -285,6 +289,9 @@
                       done.</para>
                   </listitem>
                 </itemizedlist>
+                <para>If the archive that is updated contains entries that are not mentioned in the
+                  manifest, these entries are moved to the end of the archive. In other words:
+                  entries in the manifest come first.</para>
               </listitem>
             </varlistentry>
             <varlistentry>

--- a/steps/src/main/xml/steps/archive.xml
+++ b/steps/src/main/xml/steps/archive.xml
@@ -7,7 +7,7 @@
   <para>The <code>p:archive</code> step outputs on its <port>result</port> port an archive (usually
     binary) document, for instance a ZIP file. A specification of the contents of the archive may be
     specified in a manifest XML document on the <port>manifest</port> port. The step produces a
-    report on the <port>report</port> port, which contains the manifest, amended with additional
+    report on the <port>report</port>  port, which contains the manifest, amended with additional
     information about the archiving.</para>
 
   <p:declare-step type="p:archive">

--- a/steps/src/main/xml/steps/archive.xml
+++ b/steps/src/main/xml/steps/archive.xml
@@ -125,15 +125,10 @@
       <listitem>
         <para>The <option>relative-to</option> option is used in creating a manifest when no
           manifest is provided on the <port>manifest</port> port. See <xref
-            linkend="cv.archive-manifest"/>.</para>
-        <para>The value provided for the <option>relative-to</option> option will before use always
-          be normalized using the <function>p:urify()</function> function. After this normalization
-          its value <rfc2119>must</rfc2119> be an absolute URI. <error code="D0064">It is a
-              <glossterm>dynamic error</glossterm> if the <option>relative-to</option> option is
-            present and its value is not a valid <type>xs:anyURI</type>. </error>
-          <error code="D0074">It is a <glossterm>dynamic error</glossterm> to provide a value for
-            the <option>relative-to</option> option that, after normalization by the
-              <function>p:urify()</function> function, is not an absolute URI.</error></para>
+            linkend="cv.archive-manifest"/>. The value provided for the <option>relative-to</option>
+          option will before use always be normalized using the <function>p:urify()</function>
+          function. After this normalization its value <rfc2119>must</rfc2119> be an absolute URI.
+        </para>
       </listitem>
     </varlistentry>
   </variablelist>
@@ -188,15 +183,6 @@
         <para>The <code>href</code> attribute will before use always be normalized by the
             <function>p:urify()</function> function. It is interpreted as follows:</para>
         <itemizedlist>
-          <listitem>
-            <para><error code="D0064">It is a <glossterm>dynamic error</glossterm> if the
-                  <code>c:entry/@href</code> attribute in a <code>p:archive</code> step manifest is
-                present and its value is not a valid <type>xs:anyURI</type>.</error>
-              <error code="D0074">It is a <glossterm>dynamic error</glossterm> to provide a value
-                for the <code>c:entry/@href</code> attribute in a <code>p:archive</code> step
-                manifest that, after normalization by the <function>p:urify()</function> function, is
-                not an absolute URI.</error></para>
-          </listitem>
           <listitem>
             <para>The <code>p:archive</code> step checks the documents appearing on its
                 <port>source</port> port for any documents with exactly the same base URI as the

--- a/steps/src/main/xml/steps/unarchive.xml
+++ b/steps/src/main/xml/steps/unarchive.xml
@@ -2,7 +2,7 @@
   xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.unarchive">
 
-  <title>p:unarchive</title> 
+  <title>p:unarchive</title>
 
   <para>The <code>p:unarchive</code> step outputs on its <port>result</port> port specific entries
     in an archive (for instance from a zip file).</para>
@@ -17,8 +17,9 @@
     <p:option name="relative-to" as="xs:anyURI?"/>
   </p:declare-step>
 
-  <para>The meaning and interpretation of the <code>p:unarchive</code> step's options is as follows:</para>
-  
+  <para>The meaning and interpretation of the <code>p:unarchive</code> step's options is as
+    follows:</para>
+
   <itemizedlist>
     <listitem>
       <para>The format of the archive is determined as follows:</para>
@@ -91,14 +92,14 @@
     </listitem>
     <listitem>
       <para>The <option>relative-to</option> option, when present, is used in creating the base URI
-        of the unarchived documents.</para>
-      <para>The value provided for the <option>relative-to</option> option will before use always be
-        normalized using the <function>p:urify()</function> function. After this normalization its
-        value <rfc2119>must</rfc2119> be an absolute URI. </para>
-
+        of the unarchived documents. <error code="D0064">It is a <glossterm>dynamic
+            error</glossterm> if the option is not a valid URI according to <biblioref
+            linkend="rfc3986"/>.</error> If the option is relative, it is made absolute against the
+        base URI of the element on which it is specified (<tag>p:with-option</tag> or the step in
+        case of a syntactic shortcut value).</para>
     </listitem>
   </itemizedlist>
-  
+
   <para>The base URI of an unarchived document appearing on the <port>result</port> port is: </para>
   <itemizedlist>
     <listitem>
@@ -107,23 +108,25 @@
     </listitem>
     <listitem>
       <para>If the <option>relative-to</option> option is <emphasis>not</emphasis> present: The
-        value of the  base URI of the archive appended with the relative path of this document as it
+        value of the base URI of the archive appended with the relative path of this document as it
         was in the archive</para>
     </listitem>
   </itemizedlist>
-  
-  <para>For instance, the base URI of an unarchived file called <code>xyz.xml</code> that resided
-    in the <code>specs</code> subdirectory in an archive with base URI <code>file:///a/b/c.zip</code> will become:
-  </para>
-   <itemizedlist>
-     <listitem>
-       <para>With the <option>relative-to</option> option set to <code>file:///x/y/z</code>: <code>file:///x/y/z/specs/xyz.xml</code></para>
-     </listitem>
-     <listitem>
-       <para>Without a <option>relative-to</option> option set: <code>file:///a/b/c.zip/specs/xyz.xml</code></para>
-     </listitem>
-   </itemizedlist> 
-  
+
+  <para>For instance, the base URI of an unarchived file called <code>xyz.xml</code> that resided in
+    the <code>specs</code> subdirectory in an archive with base URI <code>file:///a/b/c.zip</code>
+    will become: </para>
+  <itemizedlist>
+    <listitem>
+      <para>With the <option>relative-to</option> option set to <code>file:///x/y/z</code>:
+          <code>file:///x/y/z/specs/xyz.xml</code></para>
+    </listitem>
+    <listitem>
+      <para>Without a <option>relative-to</option> option set:
+          <code>file:///a/b/c.zip/specs/xyz.xml</code></para>
+    </listitem>
+  </itemizedlist>
+
   <simplesect>
     <title>Document properties</title>
     <para feature="archive-preserves-none">No document properties are preserved.</para>

--- a/steps/src/main/xml/steps/unarchive.xml
+++ b/steps/src/main/xml/steps/unarchive.xml
@@ -14,76 +14,121 @@
     <p:option name="exclude-filter" as="xs:string*" e:type="RegularExpression"/>
     <p:option name="format" as="xs:QName?"/>
     <p:option name="parameters" as="map(xs:Qname, item()*)?"/>
+    <p:option name="relative-to" as="xs:anyURI?"/>
   </p:declare-step>
 
-  <para>The format of the archive is determined as follows:</para>
+  <para>The meaning and interpretation of the <code>p:unarchive</code> step's options is as follows:</para>
+  
   <itemizedlist>
     <listitem>
-      <para>If the <option>format</option> option is specified, this determines the format of the
-        archive. Implementations <rfc2119>must</rfc2119> support the <biblioref linkend="zip"/>
-        format, specified with the value <code>zip</code>. <impl>It is
-            <glossterm>implementation-defined</glossterm> what other formats are supported.</impl>
-        <error code="C0081">It is a <glossterm>dynamic error</glossterm> if the format of the
-          archive does not match the format as specified in the <option>format</option>
-          option.</error></para>
+      <para>The format of the archive is determined as follows:</para>
+      <itemizedlist>
+        <listitem>
+          <para>If the <option>format</option> option is specified, this determines the format of
+            the archive. Implementations <rfc2119>must</rfc2119> support the <biblioref
+              linkend="zip"/> format, specified with the value <code>zip</code>. <impl>It is
+                <glossterm>implementation-defined</glossterm> what other formats are
+              supported.</impl>
+            <error code="C0081">It is a <glossterm>dynamic error</glossterm> if the format of the
+              archive does not match the format as specified in the <option>format</option>
+              option.</error></para>
+        </listitem>
+        <listitem>
+          <para>If no <option>format</option> option is specified or if its value is the empty
+            sequence, the archive's format will be determined by the step, using the
+              <code>content-type</code> document-property of the document on the <port>source</port>
+            port and/or by inspecting its contents. <impl>It is
+                <glossterm>implementation-defined</glossterm> how the step determines the archive's
+              format.</impl> Implementations <rfc2119>should</rfc2119> recognize archives in
+              <biblioref linkend="zip"/> format. </para>
+        </listitem>
+      </itemizedlist>
     </listitem>
     <listitem>
-      <para>If no <option>format</option> option is specified or if its value is the empty sequence,
-        the archive's format will be determined by the step, using the <code>content-type</code>
-        document-property of the document on the <port>source</port> port and/or by inspecting its
-        contents. <impl>It is <glossterm>implementation-defined</glossterm> how the step determines
-          the archive's format.</impl> Implementations <rfc2119>should</rfc2119> recognize archives
-        in <biblioref linkend="zip"/> format. </para>
+      <para>The <option>parameters</option> option can be used to supply parameters to control the
+        unarchiving. <impl>The semantics of the keys and the allowed values for these keys are
+            <glossterm>implementation-defined</glossterm>.</impl>
+        <error code="C0079">It is a <glossterm>dynamic error</glossterm> if the map
+            <option>parameters</option> contains an entry whose key is defined by the implementation
+          and whose value is not valid for that key.</error></para>
+    </listitem>
+    <listitem>
+      <para>If present, the value of the <option>include-filter</option> or
+          <option>exclude-filter</option> option <rfc2119>must</rfc2119> be a sequence of strings,
+        each one representing a regular expressions as specified in <biblioref
+          linkend="xpath31-functions"/>, section 7.61 “<literal>Regular Expression
+        Syntax</literal>”.</para>
+
+      <para>If neither the <option>include-filter</option> option nor the
+          <option>exclude-filter</option> option is specified, the <code>p:unarchive</code> step
+        outputs on its <port>result</port> port all entries in the archive.</para>
+
+      <para>If the <option>include-filter</option> option or the <option>exclude-filter</option>
+        option is specified, the <code>p:archive</code> step outputs on the <port>result</port> port
+        the entries from the archive that conform to the following rules:</para>
+      <itemizedlist>
+        <listitem>
+          <para>If any <option>include-filter</option> pattern matches an archive entry's name, the
+            entry is included in the output.</para>
+        </listitem>
+        <listitem>
+          <para>If any <option>exclude-filter</option> pattern matches an archive entry's name, the
+            entry is excluded in the output.</para>
+        </listitem>
+        <listitem>
+          <para>If both options are provided, the include filter is processed first, then the
+            exclude filter. </para>
+        </listitem>
+        <listitem>
+          <para>Names of entries in archives are always relative names. For instance, the name of a
+            file called <code>xyz.xml</code> in a <code>specs</code> subdirectory in an archive is
+            called in full <code>specs/xyz.xml</code> (and not <code>/specs/xyz.xml</code>).</para>
+        </listitem>
+      </itemizedlist>
+      <para>As a result: an item is included if it matches (at least) one of the
+          <option>include-filter</option> values and none of the <option>exclude-filter</option>
+        values.</para>
+    </listitem>
+    <listitem>
+      <para>The <option>relative-to</option> option, when present, is used in creating the base URI
+        of the unarchived documents.</para>
+      <para>The value provided for the <option>relative-to</option> option will before use always be
+        normalized using the <function>p:urify()</function> function. After this normalization its
+        value <rfc2119>must</rfc2119> be an absolute URI. <error code="D0064">It is a
+            <glossterm>dynamic error</glossterm> if the <option>relative-to</option> option is
+          present and its value is not a valid <type>xs:anyURI</type>. </error>
+        <error code="D0074">It is a <glossterm>dynamic error</glossterm> to provide a value for the
+            <option>relative-to</option> option that, after normalization by the
+            <function>p:urify()</function> function, is not an absolute URI.</error></para>
+
     </listitem>
   </itemizedlist>
-
-  <para>The <option>parameters</option> option can be used to supply parameters to control the
-    unarchiving. <impl>The semantics of the keys and the allowed values for these keys are
-        <glossterm>implementation-defined</glossterm>.</impl>
-    <error code="C0079">It is a <glossterm>dynamic error</glossterm> if the map
-        <option>parameters</option> contains an entry whose key is defined by the implementation and
-      whose value is not valid for that key.</error></para>
-
-  <para>If present, the value of the <option>include-filter</option> or
-      <option>exclude-filter</option> option <rfc2119>must</rfc2119> be a sequence of strings, each
-    one representing a regular expressions as specified in <biblioref linkend="xpath31-functions"/>,
-    section 7.61 “<literal>Regular Expression Syntax</literal>”.</para>
-
-  <para>If neither the <option>include-filter</option> option nor the
-      <option>exclude-filter</option> option is specified, the <code>p:unarchive</code> step outputs
-    on its <port>result</port> port all entries in the archive.</para>
-
-  <para>If the <option>include-filter</option> option or the <option>exclude-filter</option> option
-    is specified, the <code>p:archive</code> step outputs on the <port>result</port> port the
-    entries from the archive that conform to the following rules:</para>
+  
+  <para>The base URI of an unarchived document appearing on the <port>result</port> port is: </para>
   <itemizedlist>
     <listitem>
-      <para>If any <option>include-filter</option> pattern matches an archive entry's name, the
-        entry is included in the output.</para>
+      <para>If the <option>relative-to</option> option is present: The value of this option appended
+        with the relative path of this document as it was in the archive</para>
     </listitem>
     <listitem>
-      <para>If any <option>exclude-filter</option> pattern matches an archive entry's name, the
-        entry is excluded in the output.</para>
-    </listitem>
-    <listitem>
-      <para>If both options are provided, the include filter is processed first, then the exclude
-        filter. </para>
-    </listitem>
-    <listitem>
-      <para>Names of entries in archives are always relative names. For instance, the name of a file
-        called <code>xyz.xml</code> in a <code>specs</code> subdirectory in an archive is called in
-        full <code>specs/xyz.xml</code> (and not <code>/specs/xyz.xml</code>).</para>
+      <para>If the <option>relative-to</option> option is <emphasis>not</emphasis> present: The
+        value of the  base URI of the archive appended with the relative path of this document as it
+        was in the archive</para>
     </listitem>
   </itemizedlist>
-  <para>As a result: an item is included if it matches (at least) one of the
-      <option>include-filter</option> values and none of the <option>exclude-filter</option>
-    values.</para>
-
-  <para>The base URI of an unarchived document appearing on the <port>result</port> port is the
-    relative path of this document as it was in the archive. For instance, the base URI of an
-    unarchived file called <code>xyz.xml</code> that resided in the <code>specs</code> subdirectory
-    in the archive will become <code>specs/xyz.xml</code>.</para>
-
+  
+  <para>For instance, the base URI of an unarchived file called <code>xyz.xml</code> that resided
+    in the <code>specs</code> subdirectory in an archive with base URI <code>file:///a/b/c.zip</code> will become:
+  </para>
+   <itemizedlist>
+     <listitem>
+       <para>With the <option>relative-to</option> option set to <code>file:///x/y/z</code>: <code>file:///x/y/z/specs/xyz.xml</code></para>
+     </listitem>
+     <listitem>
+       <para>Without a <option>relative-to</option> option set: <code>file:///a/b/c.zip/specs/xyz.xml</code></para>
+     </listitem>
+   </itemizedlist> 
+  
   <simplesect>
     <title>Document properties</title>
     <para feature="archive-preserves-none">No document properties are preserved.</para>

--- a/steps/src/main/xml/steps/unarchive.xml
+++ b/steps/src/main/xml/steps/unarchive.xml
@@ -94,12 +94,7 @@
         of the unarchived documents.</para>
       <para>The value provided for the <option>relative-to</option> option will before use always be
         normalized using the <function>p:urify()</function> function. After this normalization its
-        value <rfc2119>must</rfc2119> be an absolute URI. <error code="D0064">It is a
-            <glossterm>dynamic error</glossterm> if the <option>relative-to</option> option is
-          present and its value is not a valid <type>xs:anyURI</type>. </error>
-        <error code="D0074">It is a <glossterm>dynamic error</glossterm> to provide a value for the
-            <option>relative-to</option> option that, after normalization by the
-            <function>p:urify()</function> function, is not an absolute URI.</error></para>
+        value <rfc2119>must</rfc2119> be an absolute URI. </para>
 
     </listitem>
   </itemizedlist>


### PR DESCRIPTION
This turned out to be quite a change due to our decisions that base URIs must be absolute. I had to change `p:archive`, `p:archive-manifest` and `p:unarchive`.

All three now have a `relative-to` option that can be used to set the base URI for the files *in* the archive.

I also made the choice to have all relevant URIs to be normalized first by `p:urify()`. This applies to values passed to the `relative-to` option and the values of the manifest's `c:entry/@href` attributes. IMHO this is in line with the decisions we made about this for setting base URIs on our last call.