### PR TITLE
Issue 248

### DIFF
--- a/steps/src/main/xml/steps/load.xml
+++ b/steps/src/main/xml/steps/load.xml
@@ -15,12 +15,14 @@ result a document (or documents) specified by an IRI.</para>
   <p:option name="document-properties" as="map(xs:QName, item()*)?"/>
 </p:declare-step>
 
-<para><error code="D0064">It is a <glossterm>dynamic error</glossterm> if
-the <option>href</option> URI is not a valid <type>xs:anyURI</type>.</error>
-If the <option>href</option> is relative, it is made absolute
-against the base URI of the element on which it is specified
-(<tag>p:with-option</tag> or <tag>p:load</tag> in the case of a
-syntactic shortcut value).</para>
+  <para>
+    <error code="D0064">It is a <glossterm>dynamic error</glossterm> if the <option>href</option>
+      option is not a valid URI according to <biblioref linkend="rfc3986"/>.</error> If the option is relative, it
+    is made absolute against the base URI of the element on which it is specified
+      (<tag>p:with-option</tag> or the step in case of a syntactic shortcut value). If the
+      <option>href</option> is relative, it is made absolute against the base URI of the element on
+    which it is specified (<tag>p:with-option</tag> or <tag>p:load</tag> in the case of a syntactic
+    shortcut value).</para>
 
 <para>The document or documents identified by the
 <option>href</option> URI are loaded and returned. If the URI protocol


### PR DESCRIPTION
Resolves the full issue #248.

There was only mention XD0064 (just `p:load`). So I changed this into the formulation I used before in the archive steps, so that should be ok.

@xml-project We share issue #248, but this concludes this I think, nothing more to do

See the result: https://eriksiegel.github.io/3.0-steps/Issue-248/head/steps/index.html#c.load
