### PR TITLE
First sketch of p:cast-content-type

### DIFF
--- a/steps/src/main/xml/steps/cast-content-type.xml
+++ b/steps/src/main/xml/steps/cast-content-type.xml
@@ -5,8 +5,8 @@
          xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.cast-content-type">
 <title>p:cast-content-type</title>
 
-<para>The <tag>p:cast-content-type</tag> step changes the media type
-of its input.</para>
+<para>The <tag>p:cast-content-type</tag> step creates a new document by 
+   changing the media type of its input.</para>
 
 <p:declare-step type="p:cast-content-type">
    <p:input port="source" content-types="*/*"/>
@@ -33,101 +33,197 @@ these keys are <glossterm>implementation-defined</glossterm>.</impl>
 <option>parameters</option> contains an entry whose key is defined by the
 implementation and whose value is not valid for that key.</error></para>
 
-<itemizedlist>
-<listitem>
-<para>Casting from one XML media type to another simply changes the
-“<literal>content-type</literal>” document property.
-</para>
-</listitem>
-
-<listitem>
-<para>Casting from an HTML media type to an XML media type, if the input
-document is already an XPath data model document, simply changes the
-“<literal>content-type</literal>” document property.
-<impl>Casting an HTML document that isn’t already an XPath data
-model document into XML is
-<glossterm>implementation-defined</glossterm>.</impl>
-</para>
-</listitem>
-
-<listitem>
-<para>Casting from an XML media type to an HTML media type, simply changes the
-“<literal>content-type</literal>” document property.
-</para>
-</listitem>
-
-<listitem>
-<para>Casting from a JSON media type to an XML media type, converts the
-JSON into XML. An implementation <rfc2119>must</rfc2119> support the format
-specified in section “XML Representation of JSON” of <biblioref linkend="xpath31-functions"/>
-as default for the resulting XML. <impl>It is <glossterm>implementation defined</glossterm> whether
-other result formats are supported.</impl></para>
-</listitem>
-
-<listitem>
-<para>Casting from an XML media type to a JSON media type, converts the
-XML into JSON. <impl>The precise nature of the conversion from XML to JSON
-is <glossterm>implementation-defined</glossterm>.</impl>
-If the input document is an XML representation of JSON as defined in
-<biblioref linkend="xpath31-functions"/>,
-implementations <rfc2119>must</rfc2119> use <function>fn:xml-to-json</function>
-by default. If the input document has a <tag>c:param-set</tag> document element,
-a map <rfc2119>must</rfc2119> be returned that represents the document's 
-<tag>c:param</tag> elements.
-</para>
-</listitem>
-
-<listitem xml:id="c.data">
-<para>Casting from a non-XML media type to an XML media type produces an
-XML document with a <tag>c:data</tag> document element. The original
-media type will be preserved in the
-<tag class="attribute">content-type</tag> attribute on the
-<tag>c:data</tag> element.</para>
-
-<e:rng-pattern name="VocabData"/>
-
-<para>The content of the <tag>c:data</tag> element is the base64 encoded
-representation of the non-XML content.</para>
-</listitem>
-
-<listitem>
-<para>Casting from an XML media type to a non-XML media type
-<rfc2119>must</rfc2119> support the case where the input document is
-a <tag>c:data</tag> document. The resulting document will
-have the specified media type and a representation that
-is the content of the <tag>c:data</tag> element after decoding the base64
-encoded content.</para>
-<para><error code="C0072">It is a <glossterm>dynamic
-error</glossterm> if the <tag>c:data</tag> contains content is not
-a valid base64 string.</error></para>
-<para><error code="C0073">It is a <glossterm>dynamic
-error</glossterm> if the <tag>c:data</tag> element does not have
-a <tag class="attribute">content-type</tag> attribute.</error></para>
-<para><error code="C0074">It is a <glossterm>dynamic
-error</glossterm> if the <option>content-type</option> is supplied and is
-not the same as the <tag class="attribute">content-type</tag> specified on
-the <tag>c:data</tag> element.</error>
-</para>
-<para><impl>Casting from an XML media type to a non-XML media type when
-the input document is not a <tag>c:data</tag> document is
-<glossterm>implementation-defined</glossterm>.</impl></para>
-</listitem>
-<listitem>
-<para><impl>Casting from one non-XML media type to another
-non-XML media type is <glossterm>implementation-defined</glossterm>.</impl>
-</para>
-</listitem>
-</itemizedlist>
-
-<para><error code="C075">In all cases except when the input document
-is a <tag>c:data</tag> element, it is a <glossterm>dynamic
-error</glossterm> if the <option>content-type</option> is not supplied.</error>
-</para>
-
+<section>
+   <title>Casting from an XML media type</title> 
+   <itemizedlist>
+      <listitem>
+         <para>Casting from one XML media type to another simply changes the
+            “<literal>content-type</literal>” document property.
+         </para>
+      </listitem>
+      <listitem>
+         <para>Casting from an XML media type to an HTML media type changes the
+            “<literal>content-type</literal>” document property and removes any
+            serialization property.
+         </para>
+      </listitem>
+      <listitem>
+         <para>Casting from an XML media type to a JSON media type converts the
+            XML into JSON. <impl>The precise nature of the conversion from XML to JSON
+               is <glossterm>implementation-defined</glossterm>.</impl>
+            If the input document is an XML representation of JSON as defined in
+            <biblioref linkend="xpath31-functions"/>,
+            implementations <rfc2119>must</rfc2119> use <function>fn:xml-to-json</function>
+            by default. If the input document has a <tag>c:param-set</tag> document element,
+            a map <rfc2119>must</rfc2119> be returned that represents the document's 
+            <tag>c:param</tag> elements. The serialization property is removed.
+         </para>
+      </listitem>
+      <listitem>
+         <para>Casting from an XML media type to a text media type serializes the XML document
+         by calling <function>fn:serialize($doc, $param)</function> where <literal>$doc</literal> is
+         the document on the <port>source</port> port and <literal>$param</literal> is the serialization
+         property of this document. The resulting string is wrapped by a document node and returned
+         on the <port>result</port> port. The serialization property is removed.</para>
+      </listitem>
+      <listitem>
+         <para>Casting from an XML media type to any other media type
+            <rfc2119>must</rfc2119> support the case where the input document is
+            a <tag>c:data</tag> document. The resulting document will
+            have the specified media type and a representation that
+            is the content of the <tag>c:data</tag> element after decoding the base64
+            encoded content The serialization property is removed.</para>
+         <para><error code="C0072">It is a <glossterm>dynamic
+            error</glossterm> if the <tag>c:data</tag> contains content is not
+            a valid base64 string.</error></para>
+         <para><error code="C0073">It is a <glossterm>dynamic
+            error</glossterm> if the <tag>c:data</tag> element does not have
+            a <tag class="attribute">content-type</tag> attribute.</error></para>
+         <para><error code="C0074">It is a <glossterm>dynamic
+            error</glossterm> if the <option>content-type</option> is supplied and is
+            not the same as the <tag class="attribute">content-type</tag> specified on
+            the <tag>c:data</tag> element.</error>
+         </para>
+         <para><impl>Casting from an XML media type to any other media type when
+            the input document is not a <tag>c:data</tag> document is
+            <glossterm>implementation-defined</glossterm>.</impl></para>
+      </listitem>
+   </itemizedlist>
+</section>
+   <section>
+      <title>Casting from an HTML media type</title>
+      <itemizedlist>
+         <listitem>
+            <para>Casting from an HTML media type to a XML media type changes
+               “<literal>content-type</literal>” document property and removes any
+               serialization property. </para>
+         </listitem>
+         <listitem>
+            <para>Casting from an HTML media type to another HTML media type
+            changes “<literal>content-type</literal>” document property.</para>
+         </listitem>
+         <listitem>
+            <para><impl>Casting from an HTML media type to a JSON media type is 
+               <glossterm>implementation defined</glossterm>.</impl></para>
+         </listitem>
+         <listitem>
+            <para>Casting an an HTML media type to a text media type serializes the HTML document
+               by calling <function>fn:serialize($doc, $param)</function> where <literal>$doc</literal> is
+               the document on the <port>source</port> port and <literal>$param</literal> is the serialization
+               property of this document. The resulting string is wrapped by a document node and returned
+               on the <port>result</port> port. The serialization property is removed.</para>
+         </listitem>
+         <listitem>
+            <para><impl>Casting from an HTML media type to any other media type is
+               <glossterm>implementation-defined</glossterm>.</impl></para>
+         </listitem>
+      </itemizedlist>
+   </section>
+   <section>
+      <title>Casting from a JSON media type</title>
+      <itemizedlist>
+         <listitem>
+            <para>Casting from a JSON media type to an XML media type converts the
+               JSON into XML. An implementation <rfc2119>must</rfc2119> support the format
+               specified in section “XML Representation of JSON” of <biblioref linkend="xpath31-functions"/>
+               as default for the resulting XML. <impl>It is <glossterm>implementation defined</glossterm> whether
+                  other result formats are supported.</impl> The serialization property is removed.</para>
+         </listitem>
+         <listitem>
+            <para><impl>Casting from a JSON media type to an HTML media type is
+               <glossterm>implementation-defined</glossterm>.</impl></para>
+         </listitem>
+         <listitem>
+            <para>Casting from a JSON media type to another JSON media type
+               changes “<literal>content-type</literal>” document property.</para>
+         </listitem>
+         <listitem>
+            <para>Casting from a JSON media type to a text media type serializes the JSON document
+               by calling <function>fn:serialize($doc, $param)</function> where <literal>$doc</literal> is
+               the document on the <port>source</port> port and <literal>$param</literal> is the serialization
+               property of this document. The resulting string is wrapped by a document node and returned
+               on the <port>result</port> port. The serialization property is removed.</para>
+         </listitem>
+         <listitem>
+            <para><impl>Casting from a JSON media type to any other media type is
+               <glossterm>implementation-defined</glossterm>.</impl></para>
+         </listitem>
+      </itemizedlist>
+   </section>
+   <section>
+      <title>Casting from a text media type</title>
+      <itemizedlist>
+         <listitem>
+            <para>Casting from a text media type to an XML media type parses the text value
+            of the document on <port>source</port> port by calling <function>fn:parse-xml</function>.
+            <error code="D0049">It is a <glossterm>dynamic error</glossterm> if the text value is not
+            a well-formed XML document</error>. The serialization property is removed.</para>
+         </listitem>
+         <listitem>
+            <para>Casting from a text media type to an HTML media type parsed the text value
+               of the document on <port>source</port> port into an XPath data model document that 
+               contains a tree of elements, attributes, and other nodes. <impl>The precise way in which 
+                  text documents are parsed into the XPath data model is 
+                  <glossterm>implementation-defined</glossterm>.</impl> <error code="C???2">It is a 
+                  <glossterm>dynamic error</glossterm> if the text document can not be converted into
+                  the XPath data model</error>. The serialization property is removed.</para> 
+         </listitem>
+         <listitem>
+            <para>Casting from a text media type to a JSON media type parses the text value 
+            of the document on <port>source</port> port by calling <function>fn:parse-json($doc, $par)</function>
+            where <literal>$doc</literal> is the text document and <literal>$par</literal> is the 
+               <option>parameter</option> option. <error code="D0057">It is a <glossterm>dynamic
+                  error</glossterm> if the text document does not conform to the JSON grammar, unless the 
+                  parameter liberal is true and the processor chooses to accept the deviation.</error>
+               <error code="D0058">It is a <glossterm>dynamic error</glossterm> if the parameter duplicates is 
+                  reject and the text document contains a JSON object with duplicate keys.</error>
+            <error code="D0059">It is a <glossterm>dynamic error</glossterm> if the parameter map contains 
+               an entry whose key is defined in the specification of <function>fn:parse-json</function> and 
+               whose value is not valid for that key, or if it contains an entry with the key fallback 
+               when the parameter <literal>escape</literal> with <literal>true()</literal> is also 
+               present.</error> The serialization property is removed.
+            </para>
+         </listitem>
+         <listitem>
+            <para>Casting from a text media type to another text media type changes 
+               “<literal>content-type</literal>” document property.</para>
+         </listitem>
+         <listitem>
+            <para><impl>Casting from a text media type to any other media type is
+               <glossterm>implementation-defined</glossterm>.</impl></para>
+         </listitem>
+      </itemizedlist>
+   </section>
+   <section>
+      <title>Casting from any other media type</title>
+      <itemizedlist>
+         <listitem xml:id="c.data">
+            <para>Casting from a non-XML media type to an XML media type produces an
+               XML document with a <tag>c:data</tag> document element. The original
+               media type will be preserved in the
+               <tag class="attribute">content-type</tag> attribute on the
+               <tag>c:data</tag> element.</para>
+            
+            <e:rng-pattern name="VocabData"/>
+            
+            <para>The content of the <tag>c:data</tag> element is the base64 encoded
+               representation of the non-XML content. The serialization property is removed.</para>
+         </listitem>
+         <listitem>
+            <para><impl>Casting from any other media type to a HTML media type, a JSON media type
+               or a text document is <glossterm>implementation defined</glossterm>.</impl></para>
+         </listitem>
+         <listitem>
+            <para><impl>Casting from any other media type to any other media type is <glossterm>implementation 
+               defined</glossterm>.</impl></para>
+         </listitem>
+      </itemizedlist>
+   </section>
 <simplesect>
 <title>Document properties</title>
 <para feature="cast-content-type-preserves-some">All document
 properties are preserved except the <code>content-type</code> property
-which is updated accordingly.</para>
+which is updated accordingly and the <code>serialization</code> property
+   which is removed by some casting methods.</para>
 </simplesect>
 </section>


### PR DESCRIPTION
This is a first sketch for the revised "p:cast-content-type" (see #16). I tried to include @ndw's proposal to parse and serialize e.g. xml->text and vice versa. Also I try to come up for document property "serialization" which was not covered yet.
I do not expect an approve yet, but propose to discuss this on next editors call.