### PR TITLE
Fix simple typos in cast-content-type

### DIFF
--- a/steps/src/main/xml/steps/cast-content-type.xml
+++ b/steps/src/main/xml/steps/cast-content-type.xml
@@ -35,7 +35,7 @@
          <option>parameters</option> contains an entry whose key is defined by the
          implementation and whose value is not valid for that key.</error></para>
    
-   <section>
+   <section xml:id="casting-from-xml">
       <title>Casting from an XML media type</title> 
       <itemizedlist>
          <listitem>
@@ -52,7 +52,7 @@
          <listitem>
             <para>Casting from an XML media type to a JSON media type converts the
                XML into JSON. <impl>The precise nature of the conversion from XML to JSON
-                  is <glossterm>implementation–defined</glossterm>.</impl>
+                  is <glossterm>implementation-defined</glossterm>.</impl>
                If the input document is an XML representation of JSON as defined in
                <biblioref linkend="xpath31-functions"/>,
                implementations <rfc2119>must</rfc2119> produce the same result as 
@@ -89,11 +89,11 @@
             </para>
             <para><impl>Casting from an XML media type to any other media type when
                the input document is not a <tag>c:data</tag> document is
-               <glossterm>implementation–defined</glossterm>.</impl></para>
+               <glossterm>implementation-defined</glossterm>.</impl></para>
          </listitem>
       </itemizedlist>
    </section>
-   <section>
+   <section xml:id="casting-from-html">
       <title>Casting from an HTML media type</title>
       <itemizedlist>
          <listitem>
@@ -107,7 +107,7 @@
          </listitem>
          <listitem>
             <para><impl>Casting from an HTML media type to a JSON media type is 
-               <glossterm>implementation–defined</glossterm>.</impl></para>
+               <glossterm>implementation-defined</glossterm>.</impl></para>
          </listitem>
          <listitem>
             <para>Casting an an HTML media type to a text media type serializes the HTML document
@@ -118,23 +118,23 @@
          </listitem>
          <listitem>
             <para><impl>Casting from an HTML media type to any other media type is
-               <glossterm>implementation–defined</glossterm>.</impl></para>
+               <glossterm>implementation-defined</glossterm>.</impl></para>
          </listitem>
       </itemizedlist>
    </section>
-   <section>
+   <section xml:id="casting-from-json">
       <title>Casting from a JSON media type</title>
       <itemizedlist>
          <listitem>
             <para>Casting from a JSON media type to an XML media type converts the
                JSON into XML. An implementation <rfc2119>must</rfc2119> support the format
                specified in section “XML Representation of JSON” of <biblioref linkend="xpath31-functions"/>
-               as default for the resulting XML. <impl>It is <glossterm>implementation–defined</glossterm> whether
+               as default for the resulting XML. <impl>It is <glossterm>implementation-defined</glossterm> whether
                   other result formats are supported.</impl> The serialization property is removed.</para>
          </listitem>
          <listitem>
             <para><impl>Casting from a JSON media type to an HTML media type is
-               <glossterm>implementation–defined</glossterm>.</impl></para>
+               <glossterm>implementation-defined</glossterm>.</impl></para>
          </listitem>
          <listitem>
             <para>Casting from a JSON media type to another JSON media type
@@ -149,11 +149,11 @@
          </listitem>
          <listitem>
             <para><impl>Casting from a JSON media type to any other media type is
-               <glossterm>implementation–defined</glossterm>.</impl></para>
+               <glossterm>implementation-defined</glossterm>.</impl></para>
          </listitem>
       </itemizedlist>
    </section>
-   <section>
+   <section xml:id="casting-from-text">
       <title>Casting from a text media type</title>
       <itemizedlist>
          <listitem>
@@ -167,7 +167,7 @@
                of the document on <port>source</port> port into an XPath data model document that 
                contains a tree of elements, attributes, and other nodes. <impl>The precise way in which 
                   text documents are parsed into the XPath data model is 
-                  <glossterm>implementation–defined</glossterm>.</impl> <error code="D0060">It is a 
+                  <glossterm>implementation-defined</glossterm>.</impl> <error code="D0060">It is a 
                      <glossterm>dynamic error</glossterm> if the text document can not be converted into
                      the XPath data model</error>. The serialization property is removed.</para> 
          </listitem>
@@ -193,11 +193,11 @@
          </listitem>
          <listitem>
             <para><impl>Casting from a text media type to any other media type is
-               <glossterm>implementation–defined</glossterm>.</impl></para>
+               <glossterm>implementation-defined</glossterm>.</impl></para>
          </listitem>
       </itemizedlist>
    </section>
-   <section>
+   <section xml:id="casting-from-other">
       <title>Casting from any other media type</title>
       <itemizedlist>
          <listitem xml:id="c.data">
@@ -214,11 +214,11 @@
          </listitem>
          <listitem>
             <para><impl>Casting from any other media type to a HTML media type, a JSON media type
-               or a text document is <glossterm>implementation–defined</glossterm>.</impl></para>
+               or a text document is <glossterm>implementation-defined</glossterm>.</impl></para>
          </listitem>
          <listitem>
             <para><impl>Casting from any other media type to any other media type is 
-               <glossterm>implementation–defined</glossterm>.</impl></para>
+               <glossterm>implementation-defined</glossterm>.</impl></para>
          </listitem>
       </itemizedlist>
    </section>


### PR DESCRIPTION
I fixed a few build warnings. The gloss terms used an emdash instead of a hypen in "implementation-defined"; this prevented the cross references from being found.

It turns out that all sections need to have `xml:id`s. The error if you put an `impl` in a section that doesn't have one was very odd!