### PR TITLE
Clean up the specification of p:markdown-to-html

### DIFF
--- a/src/main/xml/bibliography.xml
+++ b/src/main/xml/bibliography.xml
@@ -352,4 +352,10 @@ P. Koopman. June 2002.
   
   <bibliomixed xml:id="gzip"><abbrev>GZIP</abbrev>
     <citetitle xlink:href="https://tools.ietf.org/html/rfc1952">GZIP file format specification version 4.3</citetitle>.</bibliomixed>
+
+<bibliomixed xml:id="commonmark"><abbrev>CommonMark</abbrev>
+<citetitle xlink:href="https://spec.commonmark.org/current/">CommonMark Spec</citetitle>.
+John MacFarlane. 6 April 2019.
+</bibliomixed>
+
 </bibliography>

--- a/step-text/src/main/xml/specification.xml
+++ b/step-text/src/main/xml/specification.xml
@@ -94,6 +94,7 @@ specifications</holder>
   <appendix xml:id="references">
     <title>References</title>
     <bibliolist>
+      <bibliomixed xml:id="commonmark"/>
       <bibliomixed xml:id="xproc30"/>
       <bibliomixed xml:id="xproc30-steps"/>
     </bibliolist>

--- a/step-text/src/main/xml/steps/markdown-to-html.xml
+++ b/step-text/src/main/xml/steps/markdown-to-html.xml
@@ -1,24 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<section xml:id="c.markdown-to-html" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xlink="http://www.w3.org/1999/xlink"
-  xmlns="http://docbook.org/ns/docbook">
-  <title>p:markdown-to-html</title>
+<section xml:id="c.markdown-to-html"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns="http://docbook.org/ns/docbook">
+<title>p:markdown-to-html</title>
 
-  <para>The <code>p:markdown-to-html</code> step converts a text document in Markdown to XHTML.</para>
+<para>The <code>p:markdown-to-html</code> step converts a text document in Markdown to XHTML.</para>
 
-  <p:declare-step type="p:markdown-to-html">
-    <p:input port="source" primary="true" sequence="false" content-types="text/*"/>
-    <p:output port="result" primary="true" sequence="false" content-types="application/xhtml+xml"/>
-    <p:option name="parameters" as="map(xs:QName, item()*)?"/>
-  </p:declare-step>
+<p:declare-step type="p:markdown-to-html">
+  <p:input port="source" primary="true" content-types="text"/>
+  <p:output port="result" primary="true" content-types="html"/>
+  <p:option name="parameters" as="map(xs:QName, item()*)?"/>
+</p:declare-step>
 
-  <para>The <tag>p:markdown-to-html</tag> step expects on its <port>source</port> port a text document 
-    in Markdown syntax (TBD: REF TO MARKDOWN SPEC?) and converts this into XHTML. The result is returned 
-    on its <port>result</port> port.</para>
-  
-  <para>TBD</para>
+<para>The <tag>p:markdown-to-html</tag> step transforms a text document containing
+Markdown, for example <biblioref linkend="commonmark"/>, into HTML.
+<impl>The flavor(s) of Markdown supported and the parameters allowed are
+<glossterm>implementation-defined</glossterm>.</impl>.</para>
 
-  <simplesect>
-    <title>Document properties</title>
-    <para feature="load-preserves-none">No document properties are preserved.</para>
-  </simplesect>
+<simplesect>
+  <title>Document properties</title>
+  <para feature="load-preserves-none">No document properties are preserved.</para>
+</simplesect>
 </section>


### PR DESCRIPTION
Fix #39 

I think this counts as a fix. We've moved the other text steps into the core step library, so this one can be for the markdown step. We might find more text-like steps to add later
