### PR TITLE
Rewrite p:escape-markup and p:unescape-markup

### DIFF
--- a/src/main/xml/bibliography.xml
+++ b/src/main/xml/bibliography.xml
@@ -322,6 +322,11 @@ Project</citetitle>. SourceForge project.
 John Cowan.
 </bibliomixed>
 
+<bibliomixed xml:id="Validator.nu"><abbrev>Validator.nu</abbrev>
+<citetitle xlink:href="https://about.validator.nu/htmlparser/">The Validator.nu HTML Parser</citetitle>.
+Henri Sivonen.
+</bibliomixed>
+
 <bibliomixed xml:id="bib.uuid"><abbrev>UUID</abbrev>
 <citetitle xlink:href="http://www.itu.int/ITU-T/studygroups/com17/oid.html">ITU
 X.667: Information technology - Open Systems Interconnection -

--- a/steps/src/main/examples/parse.input.ex.xml
+++ b/steps/src/main/examples/parse.input.ex.xml
@@ -1,4 +1,0 @@
-<description>
-&lt;p>This is a chunk.&lt;/p>
-&lt;p>This is a another chunk.&lt;/p>
-</description>

--- a/steps/src/main/examples/parse.output.ex.xml
+++ b/steps/src/main/examples/parse.output.ex.xml
@@ -1,4 +1,0 @@
-<description>
-<p xmlns="http://www.w3.org/1999/xhtml">This is a chunk.</p>
-<p xmlns="http://www.w3.org/1999/xhtml">This is a another chunk.</p>
-</description>

--- a/steps/src/main/examples/serialize.input.ex.xml
+++ b/steps/src/main/examples/serialize.input.ex.xml
@@ -1,5 +1,0 @@
-<description>
-<div xmlns="http://www.w3.org/1999/xhtml">
-<p>This is a chunk of XHTML.</p>
-</div>
-</description>

--- a/steps/src/main/examples/serialize.output.ex.xml
+++ b/steps/src/main/examples/serialize.output.ex.xml
@@ -1,5 +1,0 @@
-<description>
-&lt;div xmlns="http://www.w3.org/1999/xhtml"&gt;
-&lt;p>This is a chunk of XHTML.&lt;/p&gt;
-&lt;/div&gt;
-</description>

--- a/steps/src/main/xml/references.xml
+++ b/steps/src/main/xml/references.xml
@@ -24,6 +24,7 @@
     <bibliomixed xml:id="unicodetr17"/>
     <bibliomixed xml:id="tidy"/>
     <bibliomixed xml:id="tagsoup"/>
+    <bibliomixed xml:id="Validator.nu"/>
     <bibliomixed xml:id="bib.uuid"/>
     <bibliomixed xml:id="bib.sha"/>
     <bibliomixed xml:id="zip"/>

--- a/steps/src/main/xml/steps/escape-markup.xml
+++ b/steps/src/main/xml/steps/escape-markup.xml
@@ -1,40 +1,45 @@
 <section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.escape-markup">
 <title>p:escape-markup</title>
 
-<para>The <code>p:escape-markup</code> step applies XML serialization to the
-children of the all elements that are children of the document node and 
-replaces those children with their serialization. The outcome is a list of elements with text content that
-represents the "escaped" syntax of the children as they were
-serialized.</para>
+<para>The <code>p:escape-markup</code> step serializes an XML or HTML
+document and returns the serialized form. In other words, it
+transforms the <emphasis>tag</emphasis> “<code>&lt;tag/&gt;</code>”
+into the <emphasis>text</emphasis>
+“<code>&amp;lt;tag/&amp;gt;</code>”. This operation can be reversed with the
+<tag>p:unescape-markup</tag> step.</para>
 
 <p:declare-step type="p:escape-markup">
   <p:input port="source" content-types="xml html"/>
-  <p:output port="result" content-types="xml html"/>
+  <p:output port="result" content-types="text"/>
   <p:option name="serialization" as="map(xs:QName,item()*)?"/>
 </p:declare-step>
 
-<para><error code="C0091">It is a <glossterm>dynamic error</glossterm> if
-the document on <port>source</port> port has more than one 
-top-level element.</error></para>
-
 <para>This step supports the standard serialization options as
 specified in <link linkend="xml-serialization-31"/>. These options
-control how the output markup is produced before it is escaped.
+control how the serialization is performed.
 </para>
 
 <para>For example, the input:</para>
-<programlisting language="xml"><xi:include href="../../../../build/examples/serialize.input.ex.txt" parse="text"/></programlisting>
+
+<programlisting language="xml"><![CDATA[<div xmlns="http://www.w3.org/1999/xhtml">
+<p>This is a chunk of XHTML.</p>
+</div>]]></programlisting>
+
 <para>produces:</para>
-<programlisting language="xml"><xi:include href="../../../../build/examples/serialize.output.ex.txt" parse="text"/></programlisting>
+
+<programlisting language="xml"><![CDATA[&lt;div xmlns="http://www.w3.org/1999/xhtml"&gt;
+&lt;p>This is a chunk of XHTML.&lt;/p&gt;
+&lt;/div&gt;]]></programlisting>
 
 <note xml:id="note-escaped">
-<para>The result of this step is an XML document that contains the
-Unicode characters that are the characters that result from escaping
-the input. It is not encoded characters in a serialized octet stream,
-therefore, the serialization options related to encoding characters
+<para>The result of this step is a text document (a data model
+instance) that contains the Unicode characters that are the characters
+that result from escaping the input. It <emphasis>is not</emphasis>
+encoded characters in a serialized octet stream, therefore, the
+serialization options related to encoding characters
 (<option>byte-order-mark</option>, <option>encoding</option>, and
-<option>normalization-form</option>) do not apply. They are omitted
-from the standard serialization options on this step.</para>
+<option>normalization-form</option>) do not apply. They <rfc2119>must</rfc2119>
+be ignored by the processor.</para>
 </note>
 
 <para>By default, this step <rfc2119>must not</rfc2119> generate an

--- a/steps/src/main/xml/steps/unescape-markup.xml
+++ b/steps/src/main/xml/steps/unescape-markup.xml
@@ -5,46 +5,45 @@
          xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.unescape-markup">
 <title>p:unescape-markup</title>
 
-<para>The <tag>p:unescape-markup</tag> step takes the string value of
-the document element and parses the content as if it was a Unicode
-character stream containing serialized XML. The output consists of the
-same document element with children that result from the parse. This
+<para>The <code>p:unescape-markup</code> step parses the text document
+it receives and returns an XML or HTML document. In other words, it
+transforms the <emphasis>text</emphasis>
+“<code>&amp;lt;tag/&amp;gt;</code>” into the <emphasis>tag</emphasis>
+“<code>&lt;tag/&gt;</code>”. This
 is the reverse of the <tag>p:escape-markup</tag> step.</para>
 
 <p:declare-step type="p:unescape-markup">
-  <p:input port="source" content-types="xml html"/>
+  <p:input port="source" content-types="text"/>
   <p:output port="result" content-types="xml html"/>
   <p:option name="namespace" as="xs:anyURI?"/>
+  <p:option name="wrapper" as="xs:QName?"/>
   <p:option name="content-type" as="xs:string" select="'application/xml'"/>
   <p:option name="encoding" as="xs:string?"/>
   <p:option name="charset" as="xs:string?"/>
 </p:declare-step>
 
-<para><error code="C0091">It is a <glossterm>dynamic error</glossterm> if
-the document on <port>source</port> port has more than one 
-top-level element.</error></para>
-
-<para>The value of the <option>namespace</option> option
+<para>The <option>namespace</option> option specifies a default
+namespace. Elements that are in no namespace in the parsed content
+will be placed into this namespace unless there is an in-scope
+namespace declaration that specifies a different namespace (or
+explicitly undeclares the default namespace). If specified,
+the value of the <option>namespace</option> option
 <rfc2119>must</rfc2119> be an <type>anyURI</type>. It
 <rfc2119>should</rfc2119> be absolute, but will not be
 resolved.</para>
 
-<para>When the string value is parsed, the original document element
-is preserved so that the result will be well-formed XML even if the
+<para>If a <option>wrapper</option> is provided, the resulting parsed
+content will appear as the children of an element with that name. This
+allows the step to return a well-formed XML document even if the
 content consists of multiple, sibling elements.</para>
 
-<para>The <option>namespace</option> option specifies a default
-namespace. Elements that are in no namespace in the unescaped content
-will be placed into this namespace unless there is an in-scope namespace
-declaration that specifies a different namespace (or explicitly undeclares
-the default namespace).</para>
-
 <para>The <option>content-type</option> option <rfc2119>may</rfc2119>
-be used to specify an alternate content type for the string value. An
+be used to specify an alternate content type for the text. An
 implementation <rfc2119>may</rfc2119> use a different parser to
 produce XML content depending on the specified content-type. For
 example, an implementation might provide an HTML to XHTML parser (e.g.
-<biblioref linkend="tidy"/> or <biblioref linkend="tagsoup"/>) for the
+<biblioref linkend="Validator.nu"/>,
+<biblioref linkend="tidy"/>, or <biblioref linkend="tagsoup"/>) for the
 content type '<literal>text/html</literal>'.</para>
 
 <para>All implementations <rfc2119>must</rfc2119> support the content
@@ -83,22 +82,27 @@ the character set is not specified or if the specified
 character set is not supported by the implementation.</error>
 </para>
 
-<para>The octet-stream that results from decoding the
-text <rfc2119>must</rfc2119> be interpreted using the character encoding named by
-the value of the <option>charset</option> option
-to produce a sequence of Unicode characters to parse.</para>
+<para>The octet-stream that results from decoding the text
+<rfc2119>must</rfc2119> be interpreted using the character encoding
+named by the value of the <option>charset</option> option to produce a
+sequence of Unicode characters to parse.</para>
 
 <para>If no <option>encoding</option> is specified, the character set
 is ignored, irrespective of where it was specified.</para>
 
 <para>For example, with the 'namespace' option set to the XHTML
-namespace, the following input:</para>
+namespace and the wrapper “<code>description</code>” provided, the
+following input:</para>
 
-<programlisting language="xml"><xi:include href="../../../../build/examples/parse.input.ex.txt" parse="text"/></programlisting>
+<programlisting language="xml"><![CDATA[&lt;p>This is a chunk.&lt;/p>
+&lt;p>This is a another chunk.&lt;/p>]]></programlisting>
 
 <para>would produce:</para>
 
-<programlisting language="xml"><xi:include href="../../../../build/examples/parse.output.ex.txt" parse="text"/></programlisting>
+<programlisting language="xml"><![CDATA[<description>
+<p xmlns="http://www.w3.org/1999/xhtml">This is a chunk.</p>
+<p xmlns="http://www.w3.org/1999/xhtml">This is a another chunk.</p>
+</description>]]></programlisting>
 
 <simplesect>
 <title>Document properties</title>


### PR DESCRIPTION
This PR attempts to fix #14 but it does so in a radical way: I've entirely changed the semantics of both steps!

We need these to support, for example, JSON documents that have escaped HTML in string values. However, the complexity that @xatapult notes in issue 14 is a direct consequence of the XProc 1.0 requirement that the input and output had to remain XML even when escaping and unescaping markup. That's silly in XProc 3.0, so I've removed it. Escaping takes XML or HTML and produces text. Unescaping takes text and produces XML or HTML. In order to make that work in the general case, I had to add a `wrapper` option to `p:unescape-markup`, but I think that's consistent with what we've done in other places.

(If were inventing these steps now, we might call them p:parse and p:serialize or something, but I'm inclined to leave their names alone.)

I'd like at least two other editors to approve this before we merge it. And, obviously, if anyone objects I won't merge it until we've resolved the objections.