### PR TITLE
Clarify the base-uri property of standard steps

### DIFF
--- a/steps/src/main/xml/steps/archive-manifest.xml
+++ b/steps/src/main/xml/steps/archive-manifest.xml
@@ -70,7 +70,7 @@
 
   <simplesect>
     <title>Document properties</title>
-    <para feature="archive-preserves-none">No document properties are preserved.</para>
+    <para feature="archive-manifest-preserves-none">No document properties are preserved.
+The manifest has no <property>base-uri</property>.</para>
   </simplesect>
-
 </section>

--- a/steps/src/main/xml/steps/archive.xml
+++ b/steps/src/main/xml/steps/archive.xml
@@ -420,7 +420,8 @@
 
   <simplesect>
     <title>Document properties</title>
-    <para feature="archive-preserves-none">No document properties are preserved.</para>
+    <para feature="archive-preserves-none">No document properties are preserved.
+The archive has no <property>base-uri</property>.</para>
   </simplesect>
 
 </section>

--- a/steps/src/main/xml/steps/compare.xml
+++ b/steps/src/main/xml/steps/compare.xml
@@ -50,6 +50,7 @@ summary of the differences between the two documents may appear on the
 
 <simplesect>
 <title>Document properties</title>
-<para feature="compare-preserves-none">No document properties are preserved.</para>
+<para feature="compare-preserves-none">No document properties are preserved.
+The comparison document has no <property>base-uri</property>.</para>
 </simplesect>
 </section>

--- a/steps/src/main/xml/steps/count.xml
+++ b/steps/src/main/xml/steps/count.xml
@@ -23,6 +23,7 @@ continue.</para>
 
 <simplesect>
 <title>Document properties</title>
-<para feature="count-preserves-none">No document properties are preserved.</para>
+<para feature="count-preserves-none">No document properties are preserved.
+The count document has no <property>base-uri</property>.</para>
 </simplesect>
 </section>

--- a/steps/src/main/xml/steps/error.xml
+++ b/steps/src/main/xml/steps/error.xml
@@ -54,6 +54,7 @@ element in the pipeline.</para>
 
 <simplesect>
 <title>Document properties</title>
-<para feature="error-preserves-none">No document properties are preserved.</para>
+<para feature="error-preserves-none">No document properties are preserved but
+that’s irrelevant as no document is ever produced.</para>
 </simplesect>
 </section>

--- a/steps/src/main/xml/steps/filter.xml
+++ b/steps/src/main/xml/steps/filter.xml
@@ -20,6 +20,9 @@ expression is computed dynamically.</para>
 
 <simplesect>
 <title>Document properties</title>
-<para feature="filter-preserves-none">No document properties are preserved.</para>
+<para feature="filter-preserves-none">No document properties are preserved.
+The <property>base-uri</property> property of each document will reflect the
+base URI of the selected node(s).
+</para>
 </simplesect>
 </section>

--- a/steps/src/main/xml/steps/http-request.xml
+++ b/steps/src/main/xml/steps/http-request.xml
@@ -199,6 +199,9 @@ of the step or protocol.</error>
 
 <simplesect>
 <title>Document properties</title>
-<para feature="http-request-preserves-none">No document properties are preserved.</para>
+<para feature="http-request-preserves-none">No document properties are preserved.
+The <property>base-uri</property> property of the document(s) produced will reflect
+the base URI of the retrieved document(s).
+</para>
 </simplesect>
 </section>

--- a/steps/src/main/xml/steps/insert.xml
+++ b/steps/src/main/xml/steps/insert.xml
@@ -63,7 +63,7 @@ as the source.</para>
 <simplesect>
 <title>Document properties</title>
 <para feature="insert-preserves-all">All document properties on the
-<port>source</port> port are preserved. No document properties on the
-<port>insertion</port> port are preserved.</para>
+<port>source</port> port are preserved. The document properties on the
+<port>insertion</port> port are not preserved or present in the result document.</para>
 </simplesect>
 </section>

--- a/steps/src/main/xml/steps/json-join.xml
+++ b/steps/src/main/xml/steps/json-join.xml
@@ -56,6 +56,8 @@ port <port>result</port> will not have any arrays as members. </para>
 
 <simplesect>
   <title>Document properties</title>
-  <para feature="json-join-preserves-none">No document properties are preserved.</para>
+  <para feature="json-join-preserves-none">No document properties are preserved.
+The joined document has no <property>base-uri</property>.
+</para>
 </simplesect>
 </section>

--- a/steps/src/main/xml/steps/json-merge.xml
+++ b/steps/src/main/xml/steps/json-merge.xml
@@ -59,6 +59,8 @@ port <port>result</port>.</para>
     </para>
   <simplesect>
     <title>Document properties</title>
-    <para feature="json-merge-preserves-none">No document properties are preserved.</para>
+    <para feature="json-merge-preserves-none">No document properties are preserved.
+The merged document has no <property>base-uri</property>.
+</para>
   </simplesect>
 </section>

--- a/steps/src/main/xml/steps/load.xml
+++ b/steps/src/main/xml/steps/load.xml
@@ -163,8 +163,9 @@ are <glossterm>implementation-defined</glossterm>.
 
 <simplesect>
 <title>Document properties</title>
-<para feature="load-preserves-none">No document properties are preserved.
-The properties specified in <option>document-properties</option> are applied.
+<para>The properties specified in <option>document-properties</option> are applied.
+If the properties do not specify a <property>base-uri</property>, the 
+<property>base-uri</property> property will reflect the base URI of the loaded document.
 </para>
 </simplesect>
 </section>

--- a/steps/src/main/xml/steps/pack.xml
+++ b/steps/src/main/xml/steps/pack.xml
@@ -35,6 +35,8 @@ this step does not attempt to distinguish which one.</para>
 
 <simplesect>
 <title>Document properties</title>
-<para feature="pack-preserves-none">No document properties are preserved.</para>
+<para feature="pack-preserves-none">No document properties are preserved.
+The result documents do not have a <property>base-uri</property> property.
+</para>
 </simplesect>
 </section>

--- a/steps/src/main/xml/steps/text-count.xml
+++ b/steps/src/main/xml/steps/text-count.xml
@@ -24,6 +24,8 @@ between that line and a following line that contains no characters.)
 
   <simplesect>
     <title>Document properties</title>
-    <para feature="count-preserves-none">No document properties are preserved.</para>
+    <para feature="text-count-preserves-none">No document properties are preserved.
+The count document does not have a <property>base-uri</property> property.
+</para>
   </simplesect>
 </section>

--- a/steps/src/main/xml/steps/text-join.xml
+++ b/steps/src/main/xml/steps/text-join.xml
@@ -47,6 +47,8 @@ performed.</para>
 
   <simplesect>
     <title>Document properties</title>
-    <para feature="load-preserves-none">No document properties are preserved.</para>
+    <para feature="text-join-preserves-none">No document properties are preserved.
+The joined document has no <property>base-uri</property> property.
+</para>
   </simplesect>
 </section>

--- a/steps/src/main/xml/steps/text-tail.xml
+++ b/steps/src/main/xml/steps/text-tail.xml
@@ -34,6 +34,6 @@ newline (&amp;#10;).</para>
   
   <simplesect>
     <title>Document properties</title>
-    <para feature="add-attribute-preserves-all">All document properties are preserved.</para>
+    <para feature="text-tail-preserves-all">All document properties are preserved.</para>
   </simplesect>
 </section>

--- a/steps/src/main/xml/steps/unarchive.xml
+++ b/steps/src/main/xml/steps/unarchive.xml
@@ -136,6 +136,9 @@
   
   <simplesect>
     <title>Document properties</title>
-    <para feature="archive-preserves-none">No document properties are preserved.</para>
+    <para feature="unarchive-preserves-none">No document properties are preserved.
+The <property>base-uri</property> property of each unarchived document is reflective of
+the base URI of the document.
+</para>
   </simplesect>
 </section>

--- a/steps/src/main/xml/steps/unwrap.xml
+++ b/steps/src/main/xml/steps/unwrap.xml
@@ -38,6 +38,6 @@ document node with a single text child, the result will have content type
 
 <simplesect>
 <title>Document properties</title>
-<para feature="unwrap-preserves-none">No document properties are preserved.</para>
+<para feature="unwrap-preserves-all">All document properties are preserved.</para>
 </simplesect>
 </section>

--- a/steps/src/main/xml/steps/wrap-sequence.xml
+++ b/steps/src/main/xml/steps/wrap-sequence.xml
@@ -44,6 +44,8 @@ element.
 
 <simplesect>
 <title>Document properties</title>
-<para feature="wrap-sequence-preserves-none">No document properties are preserved.</para>
+<para feature="wrap-sequence-preserves-none">No document properties are preserved.
+The document produced has no <property>base-uri</property> property.
+</para>
 </simplesect>
 </section>

--- a/steps/src/main/xml/steps/wrap.xml
+++ b/steps/src/main/xml/steps/wrap.xml
@@ -56,6 +56,6 @@ instruction nodes.</para>
 
 <simplesect>
 <title>Document properties</title>
-<para feature="wrap-preserves-none">No document properties are preserved.</para>
+<para feature="wrap-preserves-all">All document properties are preserved.</para>
 </simplesect>
 </section>

--- a/steps/src/main/xml/steps/www-form-urldecode.xml
+++ b/steps/src/main/xml/steps/www-form-urldecode.xml
@@ -28,6 +28,8 @@ retains the order of name/value pairs in the encoded string.</para>
 
 <simplesect>
 <title>Document properties</title>
-<para feature="www-form-urldecode-preserves-none">No document properties are preserved.</para>
+<para feature="www-form-urldecode-preserves-none">No document properties are preserved.
+The resulting value has no <property>base-uri</property> property.
+</para>
 </simplesect>
 </section>

--- a/steps/src/main/xml/steps/www-form-urlencode.xml
+++ b/steps/src/main/xml/steps/www-form-urlencode.xml
@@ -23,6 +23,8 @@ option, a name/value pair is created for each value.</para>
 
 <simplesect>
 <title>Document properties</title>
-<para feature="www-form-urlencode-preserves-none">No document properties are preserved.</para>
+<para feature="www-form-urlencode-preserves-none">No document properties are preserved.
+The resulting value has no <property>base-uri</property> property.
+</para>
 </simplesect>
 </section>

--- a/steps/src/main/xml/steps/xquery.xml
+++ b/steps/src/main/xml/steps/xquery.xml
@@ -194,6 +194,10 @@ validation before using XQuery:</para>
 
 <section>
 <title>Document properties</title>
-<para feature="xquery-preserves-none">No document properties are preserved.</para>
+<para feature="xquery-preserves-none">No document properties are preserved.
+The <property>base-uri</property> property of each document will
+reflect the base URI specified by the query. If the query does not
+establish a base URI, the document will not have one.
+</para>
 </section>
 </section>

--- a/steps/src/main/xml/steps/xslt.xml
+++ b/steps/src/main/xml/steps/xslt.xml
@@ -136,6 +136,11 @@
   </section>
   <simplesect>
     <title>Document properties</title>
-    <para feature="xslt-preserves-none">No document properties are preserved.</para>
+    <para feature="xslt-preserves-none">No document properties are
+    preserved. The <property>base-uri</property> property of each
+    document will reflect the base URI specified by the tranformation.
+    If the transformation does not establish a base URI, the document
+    will not have one.
+</para>
   </simplesect>
 </section>

--- a/tools/xsl/dbspec.xsl
+++ b/tools/xsl/dbspec.xsl
@@ -243,6 +243,10 @@
   <xsl:call-template name="t:inline-monoseq"/>
 </xsl:template>
 
+<xsl:template match="db:property">
+  <xsl:call-template name="t:inline-monoseq"/>
+</xsl:template>
+
 <xsl:template match="db:tag[@class='attribute']" priority="10">
   <xsl:apply-imports/>
 </xsl:template>


### PR DESCRIPTION
On reflection, I decided that it would be better to clarify the base URI of standard steps. Here's what I changed:

1. I made it explicit that `p:archive`, `p:archive-manifest`, `p:compare`, `p:count`, `p:error`, `p:json-join`, `p:json-merge`, `p:pack`, `p:text-count`, `p:text-join`, `p:wrap-sequence`, `p:www-form-urldecode`, and `p:www-form-urlencode` produce documents with no base URI.
2. I made it explicit that the base URI(s) of the document(s) produced by `p:filter`, `p:unarchive`, `p:http-request`, `p:load`, `p:xquery`, `p:xslt` reflect the base URIs that one would expect.
3. I changed `p:wrap`, `p:unwrap` to say that they preserve *all* properties instead of none. I think none was a catagorization error that we never noticed.
4. I clarified the situation for `p:insert` a little bit.