### PR TITLE
add the missing prose for #128

### DIFF
--- a/step-file/src/main/xml/specification.xml
+++ b/step-file/src/main/xml/specification.xml
@@ -462,6 +462,11 @@ steps is assumed; for background details, see
           <entry><type>xs:integer</type></entry>
           <entry>The size of the object in bytes.</entry>
         </row>
+        <row>
+          <entry><tag class="attribute">content-type</tag></entry>
+          <entry><type>xs:string</type></entry>
+          <entry>The content type, if the object is a file.</entry>
+        </row>
       </tbody>
     </tgroup>
   </informaltable>


### PR DESCRIPTION
The schema already reflects that `c:file` may have a `content-type` attribute. Now it’s also in the prose.