### PR TITLE
Fixed different spellings of a key in auth

### DIFF
--- a/steps/src/main/xml/steps/http-request.xml
+++ b/steps/src/main/xml/steps/http-request.xml
@@ -138,7 +138,7 @@ For those methods the documents on the <port>source</port> are ignored when cons
         the HTTP request. If no value or an empty map is provided, the value provided for
         HTTP header “<literal>Authorization</literal>” (if present) is used as authentication. The following keys and 
           the expected type of their associated values are predefined: “<literal>username</literal>” (<code>xs:string</code>),
-          “<literal>password</literal>” (<code>xs:string</code>), “<literal>method</literal>” (<code>xs:string</code>),
+          “<literal>password</literal>” (<code>xs:string</code>), “<literal>auth-method</literal>” (<code>xs:string</code>),
           "<literal>preemptive-auth</literal>” (<code>xs:boolean</code>), and “<literal>certificates</literal>”
           (<code>map(xs:string, item()+)+</code>). <impl>Other key value pairs in map “<literal>auth</literal>” are 
             <glossterm>implementation defined</glossterm>.</impl> <error code="C0123">It is a <glossterm>dynamic


### PR DESCRIPTION
Fixed different spelling of key "auth-method" or "method" in map "auth".