### PR TITLE
Fix grammar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ task xproc_schemas(dependsOn: [ "download_core30" ]) {
 }
 
 task download_core30(type: Download) {
-    src "$schemaBaseUri/core30.rng"
+    src "$schemaBaseUri/lib/core30.rng"
     dest file("build/core30.rng")
 }
 download_core30.onlyIf { !file("$buildDir/core30.rng").exists() }
@@ -125,7 +125,7 @@ download_core30.onlyIf { !file("$buildDir/core30.rng").exists() }
 [ "rnc", "rng" ].each { ext ->
     ["xproc", "xproc10", "xproc30"].each { base ->
         Task t = task "download_${base}_${ext}"(type: Download) {
-            src "$schemaBaseUri/$base.$ext"
+            src "$schemaBaseUri/relax-ng/$base.$ext"
             dest file("build/$base.$ext")
         }
         t.onlyIf { ! file("$buildDir/$base.$ext").exists () }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 docbookXsltBaseUri=https://cdn.docbook.org
 docbookXsltVersion=2.4.2
 xprocTocUri=https://spec.xproc.org/master/head/etc/xproc/toc.xml
-schemaBaseUri=https://spec.xproc.org/master/head/etc
+schemaBaseUri=https://grammar.xproc.org

--- a/steps/src/main/xml/specification.xml
+++ b/steps/src/main/xml/specification.xml
@@ -52,17 +52,7 @@ specifications</holder>
   xlink:href="https://www.w3.org/community/">W3C Community and Business
   Groups</link>.
   </para>
-
-<note role="editorial">
-<para><!-- funny formatting; hack --></para>
-<para>This draft is a “last call” draft. This version is stable and
-will not be updated.</para>
-<para>The current editorial draft (including
-highlighted changes from this draft) is
-<link xlink:href="http://spec.xproc.org/master/head/steps/">also available</link>.
-</para>
-</note>
-  
+ 
   <para>If you wish to make comments regarding this document, please
   send them to
   <link xlink:href="mailto:xproc-dev@w3.org">xproc-dev@w3.org</link>.


### PR DESCRIPTION
This PR gets the grammar files from github.com/xproc/3.0-grammar

(It also removes the errant 'last-call' note from the spec, since I happened to notice it.)

I don't expect either of these changes to be controversial, so I'm just going to merge them after the build passes. Unfortunately, travis-ci is down now (21 March, 10:30 UTC) so it may be a while.
