### PR TITLE
Clarified override-content-types option 

### DIFF
--- a/step-file/src/main/xml/specification.xml
+++ b/step-file/src/main/xml/specification.xml
@@ -192,9 +192,9 @@ steps is assumed; for background details, see
     
     <para>The <option>override-content-types</option> option can be used to partially override the
       content-type determination mechanism. This works just like with the
-        <option>override-content-types</option> option of <tag>p:archive-manifest</tag> and 
-      <tag>p:unarchive</tag>, except that
-      the regular expression matching is done against the paths as used for the matching of the
+        <option>override-content-types</option> option of <tag>p:archive-manifest</tag> and
+        <tag>p:unarchive</tag> (see <xspecref spec="steps" xref="override-content-type"/>), except
+      that the regular expression matching is done against the paths as used for the matching of the
         <option>include-filter</option> and <option>exclude-filter</option> options.</para>
     
     <para xml:id="cv.directory">The result document produced for the specified directory path has a <tag>c:directory</tag>
@@ -486,8 +486,8 @@ steps is assumed; for background details, see
     <para>The <option>override-content-types</option> option can be used to partially override the
       content-type determination mechanism for files. This works just like with the
         <option>override-content-types</option> option of <tag>p:archive-manifest</tag> and
-        <tag>p:unarchive</tag>, except that the regular expression matching is done against the
-      absolute URI of the file.</para>
+        <tag>p:unarchive</tag> (see <xspecref spec="steps" xref="override-content-type"/>), except
+      that the regular expression matching is done against the absolute URI of the file.</para>
 
   <para>The following attributes are standard on a returned <tag>c:file</tag> or <tag>c:directory</tag> element. All
     attributes are optional and must be absent if not applicable. Additional implementation-defined attributes may be


### PR DESCRIPTION
Just added a reference for the `override-content-types` options in the file steps to where it is explained in the core steps library.