### PR TITLE
proposal for p:run, #331

### DIFF
--- a/step-run/src/main/examples/run.xml
+++ b/step-run/src/main/examples/run.xml
@@ -1,0 +1,26 @@
+<p:run name="runme" xslt-parameters="{map{{'foo':'bar'}}}">
+  <p:with-input port="pipeline">
+    <p:inline expand-text="true">
+      <p:declare-step name="transform-n-validate">
+        <p:input name="source" primary="true" sequence="true"/>
+        <p:input name="stylesheet"/>
+        <p:input name="xsd"/>
+        <p:option name="assert-valid" as="xs:boolean" select="false()"/>
+        <p:option name="xslt-parameters" as="map(xs:QName, item()*)?"/>
+        <p:output port="result" primary="true"/>
+        <p:output port="report" pipe="report@xsdval"/>
+        <p:xslt parameters="{$xslt-parameters}">
+          <p:with-input port="stylesheet" pipe="stylesheet"/>
+        </p:xslt>
+        <p:validate-with-xml-schema assert-valid="{$assert-valid}" name="xsdval">
+          <p:with-input port="schema" pipe="xsd"/>
+        </p:validate-with-xml-schema>
+      </p:declare-step>
+    </p:inline>
+  </p:with-input>
+  <p:with-input name="source" href="my.xml"/>
+  <p:with-input name="stylesheet" href="my.xsl"/>
+  <p:with-input name="xsd" href="my.xsd"/>
+  <p:output port="result" primary="true"/>
+  <p:output port="report"/>
+</p:run>

--- a/step-run/src/main/xml/specification.xml
+++ b/step-run/src/main/xml/specification.xml
@@ -9,7 +9,7 @@
                class="ed" role="step"
                version="5.0-extension w3c-xproc">
 <info>
-<title>XProc 3.0: dynamic pipeline execution</title>
+<title>XProc 3.1: dynamic pipeline execution</title>
 <!-- defaults to date formatted <pubdate>2014-12-18</pubdate> -->
 <copyright><year>2018</year><year>2019</year><year>2020</year>
 <holder>the Contributors to the XProc 3.0 Standard Step Library
@@ -39,7 +39,7 @@ specifications</holder>
 <abstract>
 <para>This specification describes the <code>p:run</code>
 step for
-<citetitle>XProc 3.0: An XML Pipeline Language</citetitle>.</para>
+<citetitle>XProc 3.1: An XML Pipeline Language</citetitle>.</para>
 </abstract>
 
 <legalnotice xml:id="sotd" role="status">
@@ -70,6 +70,10 @@ step for
 A machine-readable description of these steps may be found in
 <link xlink:href="steps.xpl">steps.xpl</link>.
 </para>
+  
+  <note role="editorial">
+    <para>It will most probably end up in an XProc document of its own.</para>
+  </note>
 
 <para>Familarity with the general nature of <biblioref linkend="xproc30"/>
 steps is assumed; for background details, see
@@ -81,16 +85,11 @@ steps is assumed; for background details, see
 
 <para>The <tag>p:run</tag> step runs a dynamically loaded pipeline.</para>
 
-<p:declare-step type="p:run">
-  <p:input port="source" primary="true" sequence="true" content-types="any"/>
-  <p:output port="result" primary="true" content-types="any"/>
-</p:declare-step>
-
-<para>THIS IS UNREVIEWED PLACHOLDER TEXT</para>
+<e:rng-pattern name="Run"/>
 
 <para>The <tag>p:run</tag> step functions mostly like an atomic step in that
 you can define inputs connections and option values for it. However,
-unlike atomic steps, it has no defined signature. Any inputs are
+unlike atomic steps, it has no fixed signature. Any inputs are
 allowed and any outputs may be connected.
 </para>
 
@@ -110,31 +109,81 @@ valid pipeline.
 
 <para>The pipeline that appears on the pipeline port is evaluated
 using the inputs and options specified on the <tag>p:run</tag> step.
+  The default readable port of the <tag>p:run</tag> step becomes the default readable port 
+  of the pipeline.  
 <error code="C0081">It is a <glossterm>dynamic error</glossterm>
-if the pipeline has inputs that are not specified on the <tag>p:run</tag> step.
+if the pipeline has declared inputs that are not specified on the <tag>p:run</tag> step.
 </error>
 <error code="C0082">It is a <glossterm>dynamic error</glossterm>
 if the pipeline has required options that are not specified on
-the <tag>p:run</tag> step.
+the <tag>p:run</tag> invocation.
 </error>
 </para>
+  
+  <note role="editorial" xml:id="ednote-run-required-options">
+    <para>Do we really need to have C0082? Isn’t it sufficient that the dynamically executed pipeline
+    raises an error if a required option is missing?</para>
+    <para>If we raise this error on <tag>p:run</tag>, we might as well require that the types of the
+    options given on <tag>p:run</tag> be compatible with what the pipeline’s option expects. Instead
+    of raising such an error on <tag>p:run</tag>, we can wait until the pipeline is executed and any dynamic
+    errors occur in the pipeline.</para>
+  </note>
 
-<para>The outputs of the pipeline appear on the correspondingly named output
-ports of the <tag>p:run</tag> step. If the pipeline has an output is
-not bound on the <tag>p:run</tag> step, that output is discarded. If
-the <tag>p:run</tag> step has an output port that is not provided by
-the pipeline, an empty sequence appears on that port.
-</para>
+    <para>Each output port of the pipeline can appear as a same-named output port of the <tag>p:run</tag> step. In order for
+      this to happen, the port needs to be explicitly declared in the <tag>p:run</tag> step. In contrast to output declarations
+      of compound steps or of <tag>p:declare-pipeline</tag> with a subpipeline, such an output declaration may not establish a
+      connection to any port of another step or of the pipeline to be run.</para>
+    <para>If the pipeline has an output that is not declared on the <tag>p:run</tag> step, that output is discarded, and the
+      corresponding port on the <tag>p:run</tag> step does not exist. If the <tag>p:run</tag> step declares an output port that
+      is not provided by the pipeline, an empty sequence appears on that port.</para>
+  
+    <note role="editorial" xml:id="ednote-run-empty-input">
+      <para>Should we do a similar thing for inputs? That is, if the pipeline declares an input but the <tag>p:run</tag>
+        invocation doesn’t provide a connection, it is treated as if the connection were declared explicitly empty. If we do so,
+        C0081 is no error any more. </para>
+      <para>This might be useful in that it extends the range of pipelines that a given <tag>p:run</tag> invocation may run.
+        Suppose that you modified an EPUB building step by adding an input port that accepts a text document with extra CSS to
+        be used by every HTML page within the EPUB. So this extended EPUB step has an additional input port
+          <literal>extra-css</literal> in addition to its (hypothetic) normal ports <literal>source</literal> and
+          <literal>conf</literal>. It would be perfectly useful to run this extended EPUB building pipeline as if it were the
+        standard EPUB building pipeline. It will see zero documents on its <literal>extra-css</literal> port, which is
+        fine.</para>
+      <para>In that sense, a <tag>p:run</tag> invocation declares an <emphasis>interface</emphasis> that
+      the dynamically executed pipelines must implement but may extend.</para>
+      <para>We don’t do this default-to-empty for unsaturated input connections of other step invocations, do we?</para>
+      <para>Likewise, what happens if the <tag>p:run</tag> invocation has a <tag>p:with-option</tag> element (or an option
+        attribute) that does not exist in the pipeline? I suggest that this option be simply ignored, no attempt be made by the
+        processor to pass this option to the pipeline, no error raised.</para>
+    </note>
 
-<para>The <tag>p:run</tag> step is assumed to have a primary output port. If
-the pipeline evaluated does not have a primary output port, an empty
-sequence appears on that port. (Alternatively, that could be a dynamic
-error)
-</para>
 
+  
+    <note role="editorial" xml:id="ednote-run-always-primary-output">
+      <para>This was Norm’s original draft:</para>
+      <blockquote>
+        <para>The <tag>p:run</tag> step is assumed to have a primary output port. If the pipeline evaluated does not have a
+          primary output port, an empty sequence appears on that port. Alternatively, that could be a dynamic error.</para>
+      </blockquote>
+      <para>I think Norm has proposed both alternatives before he agreed that a <tag>p:run</tag> step needs
+        to declare its outputs. With these output declarations mandatory, can we safely omit the primary port requirement?</para>
+    </note>
+  
+
+    <section xml:id="example-run">
+      <title>Example</title>
+      <example xml:id="ex.c.run">
+        <title>Dynamic Execution of a Transformation/Validation Pipeline</title>
+        <programlisting language="xml"><xi:include href="../../../build/examples/run.txt" parse="text"/></programlisting>
+      </example>
+    </section>
+  
 <section>
 <title>Document properties</title>
 <para feature="exec-preserves-none">No document properties are preserved.</para>
+      <note role="editorial" xml:id="ednote-run-docprops">
+        <para>Shouldn’t we say, the extent to which document properties are preserved depend on the steps
+        in the dynamically executed pipeline?</para>
+      </note>
 </section>
 </section>
 

--- a/step-run/src/main/xml/specification.xml
+++ b/step-run/src/main/xml/specification.xml
@@ -85,7 +85,13 @@ steps is assumed; for background details, see
 
 <para>The <tag>p:run</tag> step runs a dynamically loaded pipeline.</para>
 
-<e:rng-pattern name="Run"/>
+<!--<e:rng-pattern name="Run"/>-->
+  <note role="editorial">
+      <para>GI 2020-04-26: I commented out <literal>&lt;e:rng-pattern name="Run"/></literal> temporarily since I don’t know how
+        to render the pattern that is currently in <link
+          xlink:href="https://github.com/gimsieke/3.0-grammar/blob/run/steps/step-run/steps.rnc">steps/step-run/steps.rnc</link>
+          (<link xlink:href="https://github.com/xproc/3.0-grammar/pull/17">PR</link> pending).</para>
+  </note>
 
 <para>The <tag>p:run</tag> step functions mostly like an atomic step in that
 you can define inputs connections and option values for it. However,
@@ -173,7 +179,32 @@ the <tag>p:run</tag> invocation.
       <title>Example</title>
       <example xml:id="ex.c.run">
         <title>Dynamic Execution of a Transformation/Validation Pipeline</title>
-        <programlisting language="xml"><xi:include href="../../../build/examples/run.txt" parse="text"/></programlisting>
+        <programlisting language="xml">&lt;p:run name="runme" xslt-parameters="{map{{'foo':'bar'}}}">
+  &lt;p:with-input port="pipeline">
+    &lt;p:inline expand-text="true">
+      &lt;p:declare-step name="transform-n-validate">
+        &lt;p:input name="source" primary="true" sequence="true"/>
+        &lt;p:input name="stylesheet"/>
+        &lt;p:input name="xsd"/>
+        &lt;p:option name="assert-valid" as="xs:boolean" select="false()"/>
+        &lt;p:option name="xslt-parameters" as="map(xs:QName, item()*)?"/>
+        &lt;p:output port="result" primary="true"/>
+        &lt;p:output port="report" pipe="report@xsdval"/>
+        &lt;p:xslt parameters="{$xslt-parameters}">
+          &lt;p:with-input port="stylesheet" pipe="stylesheet"/>
+        &lt;/p:xslt>
+        &lt;p:validate-with-xml-schema assert-valid="{$assert-valid}" name="xsdval">
+          &lt;p:with-input port="schema" pipe="xsd"/>
+        &lt;/p:validate-with-xml-schema>
+      &lt;/p:declare-step>
+    &lt;/p:inline>
+  &lt;/p:with-input>
+  &lt;p:with-input name="source" href="my.xml"/>
+  &lt;p:with-input name="stylesheet" href="my.xsl"/>
+  &lt;p:with-input name="xsd" href="my.xsd"/>
+  &lt;p:output port="result" primary="true"/>
+  &lt;p:output port="report"/>
+&lt;/p:run></programlisting>
       </example>
     </section>
   


### PR DESCRIPTION
@ndw I referenced `<e:rng-pattern name="Run"/>` in specification.xml. The pattern probably needs to be defined by that name in core30.rnc in the grammar repo. Maybe you can change that after you merged https://github.com/xproc/3.0-grammar/pull/17