### PR TITLE
Attempt to resolve #395 (initial context item value)

### DIFF
--- a/steps/src/main/xml/steps/xslt.xml
+++ b/steps/src/main/xml/steps/xslt.xml
@@ -47,11 +47,23 @@
     PSVI annotations.</para>
   <para>The interpretation of the input and output ports as well as for the other options depends on
     the selected XSLT version.</para>
+  
   <section>
     <title>Invoking an XSLT 3.0 stylesheet</title>
     <para>The value of <option>global-context-item</option> is used as global context item for the
-      stylesheet invocation. If no value is supplied, the empty sequence is supplied to the
-      invocation.</para>
+      stylesheet invocation. If no value is supplied, the following applies:</para>
+    <itemizedlist>
+      <listitem>
+        <para>If there is a single document on the <port>source</port> port, this document will
+          become the value of the <option>global-context-item</option> option. Implementations
+            <rfc2119>should</rfc2119> provide node-identity between the global context item and the
+          document on the source port.</para>
+      </listitem>
+      <listitem>
+        <para>If there are none or multiple documents on the <port>source</port> port, its value
+          will be the empty sequence.</para>
+      </listitem>
+    </itemizedlist>
     <para>If no value is supplied for <option>template-name</option> option an “Apply-template
       invocation” is performed. The documents that appear on <port>source</port> are taken to be the
       initial match selection. The default collection is undefined. If a value is supplied for 


### PR DESCRIPTION
Changes for issue #395 

@achim: I formulated the node-identity as: 

> Implementations **should** provide node-identity between the global context item and the document on the source port.

I think this is better than "implementation defined": It is now a recommendation but if a processor for whatever reason can't do it, it's free to not implement it. But if you think another way of saying it is more appropriate, let me know.