### PR TITLE
Remove rnc build from p:run step

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -341,7 +341,7 @@ task step_run(type: DocBookTask,
                             "steps", "xproc_schemas", "spec_schemas",
                             "step-run:specification",
                             "step_run_assets",
-                            "step_run_src", "step_run_xpl" ]) {
+                            "step_run_src" ]) {
   inputs.files fileTree(dir: "tools/xsl/")
   inputs.files fileTree(dir: "tools/xpl/")
   inputs.file "build/xproc/toc.xml"
@@ -376,13 +376,6 @@ task step_run_src(dependsOn: ["step-run:source"], type: Copy) {
   into "build/dist/run/"
   include "source.xml"
   rename ("source.xml", "specification.xml")
-}
-
-task step_run_xpl(dependsOn: ["step-run:library"], type: Copy) {
-  from "step-run/build/"
-  into "build/dist/run/"
-  include "library.xml"
-  rename ("library.xml", "steps.xpl")
 }
 
 // ======================================================================

--- a/step-run/build.gradle
+++ b/step-run/build.gradle
@@ -56,35 +56,7 @@ task glossary(dependsOn: ["xinclude"], type: XMLCalabashTask) {
   pipeline "../tools/xpl/makeglossary.xpl"
 }
 
-task library(dependsOn: ["source"], type: XMLCalabashTask) {
-  inputs.file "build/source.xml"
-  inputs.file "../tools/xpl/typed-pipeline-library.xpl"
-  inputs.file "../tools/xsl/typed-pipeline-library.xsl"
-  outputs.file "build/library.xml"
-  input("source", "build/source.xml")
-  output("result", "build/library.xml")
-  pipeline "../tools/xpl/typed-pipeline-library.xpl"
-}
-
-task rnc(dependsOn: ["library"], type: XMLCalabashTask) {
-  inputs.file "build/library.xml"
-  inputs.file "../tools/xpl/library-to-rnc.xpl"
-  inputs.file "../tools/xsl/library-to-rnc.xsl"
-  outputs.file "build/steps.rnc"
-  input("source", "build/library.xml")
-  output("result", "build/steps.rnc")
-  pipeline "../tools/xpl/library-to-rnc.xpl"
-}
-
-task rng(dependsOn: ["rnc"], type: JavaExec) {
-  inputs.file "build/steps.rnc"
-  outputs.file "build/steps.rng"
-  classpath = configurations.tools
-  main = 'com.thaiopensource.relaxng.translate.Driver'
-  args = ["build/steps.rnc", "build/steps.rng"]
-}
-
-task specification(dependsOn: [ "source", "library", "rng" ]) {
+task specification(dependsOn: [ "source" ]) {
   // nop
 }
 


### PR DESCRIPTION
This PR disables the build system's attempt to create an RNC file and an XPL file for the `p:run` step. Because it doesn't have one. Because it's magic. We'll probably need to do something to make it validate, but this will at least resolve the build issues.