### PR TITLE
try to e:rng-pattern 'Step-run', #421

### DIFF
--- a/step-run/src/main/xml/specification.xml
+++ b/step-run/src/main/xml/specification.xml
@@ -85,13 +85,7 @@ steps is assumed; for background details, see
 
 <para>The <tag>p:run</tag> step runs a dynamically loaded pipeline.</para>
 
-<!--<e:rng-pattern name="Run"/>-->
-  <note role="editorial">
-      <para>GI 2020-04-26: I commented out <literal>&lt;e:rng-pattern name="Run"/></literal> temporarily since I don’t know how
-        to render the pattern that is currently in <link
-          xlink:href="https://github.com/gimsieke/3.0-grammar/blob/run/steps/step-run/steps.rnc">steps/step-run/steps.rnc</link>
-          (<link xlink:href="https://github.com/xproc/3.0-grammar/pull/17">PR</link> pending).</para>
-  </note>
+<e:rng-pattern name="Step-run"/>
 
 <para>The <tag>p:run</tag> step functions mostly like an atomic step in that
 you can define inputs connections and option values for it. However,


### PR DESCRIPTION
The pattern in the grammar repo isn’t up to date, see https://github.com/xproc/3.0-steps/issues/421#issuecomment-648902388. I’ll try to include the current pattern nevertheless.