### PR TITLE
Fix obscurity for secondary results of p:xslt version 3.0

### DIFF
--- a/steps/src/main/xml/steps/xslt.xml
+++ b/steps/src/main/xml/steps/xslt.xml
@@ -81,7 +81,10 @@
         template.</error></para>
     <para>Independent of the way the stylesheet is invoked, the principal result(s) will appear on
       output port <port>result</port> while secondary result(s) will appear on output port
-      <port>secondary</port>. Whether the raw results are delivered or a result tree is
+      <port>secondary</port>. <impl>The order in which 
+        result documents appear on the <port>secondary</port> port is
+        <glossterm>implementation dependent</glossterm>.</impl> 
+      Whether the raw results are delivered or a result tree is
       constructed, depends on the (explicit or implicit) setting for attribute
       <literal>build-tree</literal> of in the output-definition for the respective result. If a
       result tree is constructed, the result will be a text document if it is a single text node


### PR DESCRIPTION
As there has been a discussion whether documents on port "secondary" of p:xslt 3.0 are ordered, I added the "unordered" note from the 2.0 section to the 3.0 section as well.
I do take this to be purely editorial, correcting an oversight. So no entry in the change log is needed.