### PR TITLE
Fixed typo in p:xslt

### DIFF
--- a/steps/src/main/xml/steps/xslt.xml
+++ b/steps/src/main/xml/steps/xslt.xml
@@ -43,7 +43,7 @@
       <glossterm>implementation-dependent</glossterm>.</impl> Implementations
     <rfc2119>should</rfc2119> raise an error using the error code from the XSLT step (for example,
     the <tag class="attribute">error-code</tag> specified on the <tag>xsl:message</tag> or
-    <code>err:XTTM9000</code> if no code is provided).</para>
+    <code>Q{http://www.w3.org/2005/xqt-errors}XTTM9000</code> if no code is provided).</para>
   <para>If XSLT 2.0 or XSLT 3.0 is used, the outputs of this step <rfc2119>may</rfc2119> include
     PSVI annotations.</para>
   <para>The interpretation of the input and output ports as well as for the other options depends on


### PR DESCRIPTION
Just fixed a typo because prefix "err" is bound to "http://www.w3.org/ns/xproc-error" in the rest of the doc.