### PR TITLE
Fix content-type of port source

### DIFF
--- a/step-mail/src/main/xml/specification.xml
+++ b/step-mail/src/main/xml/specification.xml
@@ -79,7 +79,7 @@ linkend="xproc30"/> steps is assumed; for background details, see
 <para>The <code>p:send-mail</code> step sends an email message.</para>
 
 <p:declare-step type="p:send-mail">
-  <p:input port="source" sequence="true" content-types="xml"/>
+  <p:input port="source" sequence="true" content-types="any"/>
   <p:output port="result" content-types="application/xml"/>
   <p:option name="serialization" as="map(xs:QName,item()*)?"/>
   <p:option name="auth" as="map(xs:string, item()+)?" />


### PR DESCRIPTION
From the prose it is clear that port `source` must accept _any_ content-type.
Sorry for missing this.