### PR TITLE
Fix example in p:error

### DIFF
--- a/steps/src/main/xml/steps/error.xml
+++ b/steps/src/main/xml/steps/error.xml
@@ -29,11 +29,9 @@ appear on it since the step always fails.</para>
 <para>For example, given the following invocation:</para>
 <programlisting language="xml">&lt;p:error xmlns:my="http://www.example.org/error"
          name="bad-document" code="my:unk12"&gt;
-   &lt;p:input port="source"&gt;
-     &lt;p:inline&gt;
-       &lt;message&gt;The document element is unknown.&lt;/message&gt;
-     &lt;/p:inline&gt;
-   &lt;/p:input&gt;
+   &lt;p:with-input port="source"&gt;
+     &lt;message&gt;The document element is unknown.&lt;/message&gt;
+   &lt;/p:with-input&gt;
 &lt;/p:error&gt;</programlisting>
 
 <para>The error vocabulary element (and document) generated on the


### PR DESCRIPTION
Fix for the error in the example of `p:error` #445 

Also remove the superfluous `p:inline`. The shorter the better here as far as I'm concerned.