### PR TITLE
Fix typo in directory-list

### DIFF
--- a/step-file/src/main/xml/specification.xml
+++ b/step-file/src/main/xml/specification.xml
@@ -85,7 +85,7 @@ steps is assumed; for background details, see
       of a specified directory.</para>
     
     <p:declare-step type="p:directory-list">
-      <p:output port="result" content-type="application/xml"/>
+      <p:output port="result" content-types="application/xml"/>
       <p:option name="path" required="true" as="xs:anyURI"/>
       <p:option name="detailed" as="xs:boolean" select="false()"/>
       <p:option name="max-depth" as="xs:string?" select="'1'"/>


### PR DESCRIPTION
The attribute on `p:output` is `content-types`, not `content-type`.

(I don't know what the list of `Add .circleci/config.yml` commits is about. I think they're ones I squashed away.)