### PR TITLE
Added error code for invalid multipart boundary

### DIFF
--- a/steps/src/main/xml/steps/http-request.xml
+++ b/steps/src/main/xml/steps/http-request.xml
@@ -473,7 +473,10 @@ header:</para>
 <para>If the “<literal>content-type</literal>” header specifies a
 multipart content type, that value will be used as the content type. If the
 header includes a <literal>boundary</literal> parameter, that value
-will be used as the boundary.</para>
+will be used as the boundary.
+<error code="C0203">It is a <glossterm>dynamic error</glossterm>
+if the specified boundary is not valid (for example, if it begins with two hyphens “--”).</error>
+</para>
 </listitem>
 <listitem>
 <para>If the “<literal>content-type</literal>” header is not specified,


### PR DESCRIPTION
If the user specifies a boundary for a multipart request that's not valid (e.g., if it begins "--"), throw this error.