### PR TITLE
Report the base URI in the report output

### DIFF
--- a/steps/src/main/xml/steps/http-request.xml
+++ b/steps/src/main/xml/steps/http-request.xml
@@ -56,11 +56,34 @@ port. Each document in the response will be parsed according to
 its content-type (but see “<literal>override-content-type</literal>”
 in the <option>parameters</option> option).
 Details about the outcome of the request will appear as a map on
-the <port>report</port> port. The map will always contain
-“<literal>status-code</literal>” (an <code>xs:integer</code>) and
-“<literal>headers</literal>” (a <code>map(xs:string,
-xs:string)</code>). The header map may be empty. Header names are
-converted to lowercase.</para>
+the <port>report</port> port. The map will always contain:
+</para>
+
+<variablelist>
+<varlistentry>
+  <term><literal>status-code</literal> (an <code>xs:integer</code>)</term>
+  <listitem>
+    <para>This is the HTTP status code returned for the request.</para>
+  </listitem>
+</varlistentry>
+<varlistentry>
+  <term><literal>base-uri</literal> (an <code>xs:anyURI</code>)</term>
+  <listitem>
+    <para>This is the URI of the last request made and is always
+    available in the report even when the request does not return any
+    documents. In the case of HTTP redirection, the base URI returned
+    may be different from the original request URI.
+    </para>
+  </listitem>
+</varlistentry>
+<varlistentry>
+  <term><literal>headers</literal> (a <code>map(xs:string, xs:string)</code>)</term>
+  <listitem>
+    <para>These are the HTTP headers returned for the request. The map may be
+empty. Header names are converted to lowercase.</para>
+  </listitem>
+</varlistentry>
+</variablelist>
 
 <para>The <tag>p:http-request</tag> step has the following options:</para>
 <variablelist>


### PR DESCRIPTION
In the course of debugging my `p:http-request` step and discussing the various test outcomes with @xml-project, the following observation was made:

If a request produces no documents, it's impossible to tell what the final URI was. In particular, consider the case where you've set `follow-redirect` to 2 but the request redirects more than twice. There's no output so there's no document from which you can get the base URI, so there's no way to know what the last redirect location was.

The simple fix seems to be to add this information to the `report` output. It seems reasonable, it's trivial to implement, and it does mean pipeline authors can rely on reading the value irrespective of whether or not a document was produced.
