### PR TITLE
Attempt to resolve issue #485

### DIFF
--- a/steps/src/main/xml/steps/delete.xml
+++ b/steps/src/main/xml/steps/delete.xml
@@ -36,6 +36,6 @@ of the element on which it occurred.</para>
    <para feature="delete-preserves-partially">If the resulting document contains exactly one text node,
       the <literal>content-type</literal> property is changed to <literal>text/plain</literal> and the 
       <literal>serialization</literal> property is removed, while all other document properties are 
-      preserved. For other document types, all document properties are preserved.</para>
+      preserved. In all other cases, all document properties are preserved.</para>
 </simplesect>
 </section>

--- a/steps/src/main/xml/steps/unwrap.xml
+++ b/steps/src/main/xml/steps/unwrap.xml
@@ -10,7 +10,7 @@ children.</para>
 
 <p:declare-step type="p:unwrap">
    <p:input port="source" content-types="xml html"/>
-   <p:output port="result" content-types="application/xml text/plain"/>
+  <p:output port="result" content-types="text xml html"/>
    <p:option name="match" as="xs:string" select="'/*'" e:type="XSLTSelectionPattern"/>
 </p:declare-step>
 
@@ -41,8 +41,7 @@ ones.</para>
     </listitem>
     <listitem>
       <para>If a document consisting of only an empty root element is unwrapped, the result will be
-        a document node without children. The result document&#x2019;s content type will become
-          “<literal>text/plain</literal>”.</para>
+        a document node without children. The result document&#x2019;s content type will not change.</para>
     </listitem>
     <listitem>
       <para>If a document consisting of a root element containing only text is unwrapped, the result will be
@@ -56,9 +55,9 @@ ones.</para>
   
 <simplesect>
 <title>Document properties</title>
-    <para feature="unwrap-preserves-all">All document properties are preserved unless the step
-      changes the document&#x2019;s content type. In that case the <code>content-type</code> document
-      property will reflect the new content type and the (optional) <code>serialization</code> document
-      property will be removed.</para>
+  <para feature="unwrap-preserves-partially">If the resulting document contains exactly one text node,
+    the <literal>content-type</literal> property is changed to <literal>text/plain</literal> and the 
+    <literal>serialization</literal> property is removed, while all other document properties are 
+    preserved. In all other cases, all document properties are preserved.</para>
 </simplesect>
 </section>


### PR DESCRIPTION
`p:delete` and `p:unwrap` now have the same behavior if the result is an empty document node, as discussed.

I also fixed a bug/oversight in `p:unwrap`'s step signature (the output port content types still looked like an XProc 1 leftover)