### PR TITLE
Fix the sequence type of the default-version option

### DIFF
--- a/step-validation/src/main/xml/specification.xml
+++ b/step-validation/src/main/xml/specification.xml
@@ -463,13 +463,13 @@ No document properties on the <port>schemas</port> port are preserved.</para>
     <p:output port="result" primary="true" content-types="json"/>
     <p:output port="report" sequence="true" content-types="xml json"/>
     <p:option name="assert-valid" select="true()" as="xs:boolean"/>
-    <p:option name="default-version" as="xs:string" />
+    <p:option name="default-version" as="xs:string?" />
     <p:option name="parameters" as="map(xs:QName,item()*)?"/>
     <p:option name="report-format" select="'xvrl'" as="xs:string"/>
   </p:declare-step>
 
   <para>The option <option>default-version</option> can be used to
-  control the schema's version in case it does not specify one itself.<impl>If
+  control the schema's version in case it does not specify one itself. <impl>If
   the schema does not specify a version and option <option>default-version</option>
   is empty, the version used is <glossterm>implementation-defined</glossterm>.</impl></para>
 
@@ -491,6 +491,12 @@ No document properties on the <port>schemas</port> port are preserved.</para>
       on the <port>result</port> port. No document properties on the <port>schemas</port> are preserved. 
       No document properties are preserved on the <port>report</port> port.</para>
   </simplesect>
+
+<simplesect>
+<title>Errata, April 2024</title>
+<para>Corrected an error in the sequence type for the <code>default-version</code> option
+to allow it to be optional.</para>
+</simplesect>
 </section>  
   
 <section xmlns="http://docbook.org/ns/docbook" xml:id="errors">


### PR DESCRIPTION
(Assuming this will be an uncontroversial change.)

Fix #556 

Also added missing `impl` markup around the use of an implementation-defined glossterm.