### PR TITLE
Improve the wording about matching document nodes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
+org.gradle.jvmargs=-Xmx4096M
+
 docbookXsltBaseUri=https://cdn.docbook.org
 docbookXsltVersion=2.5.0
 xprocTocUri=https://spec.xproc.org/master/head/etc/xproc/toc.xml

--- a/step-validation/src/main/xml/specification.xml
+++ b/step-validation/src/main/xml/specification.xml
@@ -469,9 +469,9 @@ No document properties on the <port>schemas</port> port are preserved.</para>
   </p:declare-step>
 
   <para>The option <option>default-version</option> can be used to
-  control the schema's version in case it does not specify one itself. If
+  control the schema's version in case it does not specify one itself.<impl>If
   the schema does not specify a version and option <option>default-version</option>
-  is empty, the version used is <glossterm>implementation-defined</glossterm>.</para>
+  is empty, the version used is <glossterm>implementation-defined</glossterm>.</impl></para>
 
   <para><error code="C0163">It is a <glossterm>dynamic error</glossterm> 
     if the selected version is not supported.</error></para>

--- a/steps/src/main/xml/steps/hash.xml
+++ b/steps/src/main/xml/steps/hash.xml
@@ -61,9 +61,8 @@ value of the attribute in the output.
 If the attribute is named “<tag class="attribute">xml:base</tag>”, the base URI
 of the element <rfc2119>must</rfc2119> also be amended accordingly.</para>
 
-<para>If the document node is matched, the entire document is replaced by a text node
-with the hash. What appears on port <port>result</port> is a text document with the
-text node wrapped in a document node.</para>
+<para>If the document node is matched, the result is a document node
+containing a single text node.</para>
 
 <para>If the expression matches any
 other kind of node, the entire node (and <emphasis>not</emphasis> just

--- a/steps/src/main/xml/steps/replace.xml
+++ b/steps/src/main/xml/steps/replace.xml
@@ -27,10 +27,9 @@ pattern is replaced in the output by the top-level node(s)
 of the <port>replacement</port> document. Only non-nested matches are
 replaced. That is, once a node is replaced, its descendants cannot
 be matched.</para>
-   
-<para>If the document node is matched and port <port>replacement</port> contains
-a text document, the entire document is replaced by the text node. What appears on port 
-<port>result</port> is a text document with the text node wrapped in a document node.</para>
+
+<para>If the document node is matched, the result is a document node
+containing the replacement.</para>
 
 <simplesect>
 <title>Document properties</title>

--- a/steps/src/main/xml/steps/string-replace.xml
+++ b/steps/src/main/xml/steps/string-replace.xml
@@ -37,9 +37,8 @@ expression is used as the new value of the attribute in the output.
 If the attribute is named “<tag class="attribute">xml:base</tag>”, the base URI
 of the element <rfc2119>must</rfc2119> also be amended accordingly.</para>
 
-<para>If the document node is matched, the entire document is replaced by the string
-value of the <option>replace</option> expression. What appears on port <port>result</port> 
-is a text document with the text node wrapped in a document node.</para>
+<para>If the document node is matched, the result is a document node
+containing a single text node.</para>
 
 <para>If the expression matches any other kind of node, the entire
 node (and <emphasis>not</emphasis> just its contents) is replaced by

--- a/steps/src/main/xml/steps/uuid.xml
+++ b/steps/src/main/xml/steps/uuid.xml
@@ -45,9 +45,8 @@ matches an <emphasis>attribute</emphasis>, the UUID is used as the new
 value of the attribute in the output. If the attribute is named “<tag class="attribute">xml:base</tag>”, the base URI of the element
 <rfc2119>must</rfc2119> also be amended accordingly.</para>
 
-<para>If the document node is matched, the entire document is replaced by a text node
-with the UUID. What appears on port <port>result</port> is a text document with the
-text node wrapped in a document node.</para>
+<para>If the document node is matched, the result is a document node
+containing a single text node.</para>
 
 <para>If the expression matches any
 other kind of node, the entire node (and <emphasis>not</emphasis> just


### PR DESCRIPTION
Fix #566 

I think I've made the prose more parallel with the discussion about attributes and less likely to confuse men of small brain like me.

I also fixed a markup error in the step-validation specification and tweaked Gradle's daemon memory, but those should be irrelevant.