### PR TITLE
Attempt to clarify p:archive parameters

### DIFF
--- a/steps/src/main/xml/steps/archive.xml
+++ b/steps/src/main/xml/steps/archive.xml
@@ -112,8 +112,10 @@
       <term><option>parameters</option></term>
       <listitem>
         <para>The <option>parameters</option> option can be used to supply parameters to control the
-          archiving. <impl>The semantics of the keys and the allowed values for these keys are
-              <glossterm>implementation-defined</glossterm>.</impl>
+          archiving. Several parameters are defined for processing
+          <link linkend="cv.archive-zips">zip archives</link>, but implementations are
+          free to use additional parameters and to use parameters for controlling
+          how other archive formats are processed.
           <error code="C0079">It is a <glossterm>dynamic error</glossterm> if the map
               <option>parameters</option> contains an entry whose key is defined by the
             implementation and whose value is not valid for that key.</error></para>


### PR DESCRIPTION
Close #562 

In the end, my editorial choice was to remove the explicit declaration that they are implementation defined. They aren't for ZIP archives, so I feel justified :-)
