### PR TITLE
Prepare for 3.1 publication

### DIFF
--- a/steps/src/main/xml/specification.xml
+++ b/steps/src/main/xml/specification.xml
@@ -323,6 +323,8 @@ by adding a <tag>p:sleep</tag> step.
 <listitem>
 <para>Resolved <link xlink:href="https://github.com/xproc/Vnext/issues/39">V.next issue 29</link> by
 allowing the text documents on the <port>insertion</port> port of the <tag>p:insert</tag> step.
+Resolved <link xlink:href="https://github.com/xproc/3.0-steps/issues/583">issue 583</link> by
+allowing text documents on the <port>result</port> port.
 </para>
 </listitem>
 </itemizedlist>

--- a/steps/src/main/xml/specification.xml
+++ b/steps/src/main/xml/specification.xml
@@ -9,13 +9,14 @@
                class="ed"
                version="5.0-extension w3c-xproc">
 <info>
-<title>XProc 3.0+: Standard Step Library</title>
+<title>XProc 3.1: Standard Step Library</title>
 <!--
 <pubdate>2022-09-12</pubdate>
 <bibliomisc role="final-uri">https://spec.xproc.org/3.0/steps/</bibliomisc>
 -->
 <copyright><year>2018</year><year>2019</year><year>2020</year><year>2021</year><year>2022</year>
-<holder>the Contributors to the XProc 3.0 Standard Step Library
+<year>2023</year><year>2024</year>
+<holder>the Contributors to the XProc 3.1 Standard Step Library
 specifications</holder>
 </copyright>
 
@@ -45,7 +46,7 @@ specifications</holder>
 
 <abstract>
   <para>This specification describes the standard step vocabulary of
-  <citetitle>XProc 3.0: An XML Pipeline Language</citetitle>.</para>
+  <citetitle>XProc 3.1: An XML Pipeline Language</citetitle>.</para>
 </abstract>
 
 <legalnotice xml:id="sotd" role="status">
@@ -68,8 +69,8 @@ specifications</holder>
   </para>
 
 <note role="editorial">
-<para>This draft is the “editor’s working draft” and includes changes made
-after the XProc 3.0 standard step specification was released.
+<para>This draft is the “editor’s working draft” and may continue to evolve.
+A “last call” working draft is anticipated shortly.
 </para>
 </note>
 
@@ -278,102 +279,93 @@ PSVI annotations.</para>
 <appendix xml:id="changelog">
 <title>Change Log</title>
 
-<para>This appendix catalogs non-editorial changes made after the August 2020
-“<link xlink:href="https://spec.xproc.org/lastcall-2020-08/head/steps/">last call</link>”
-draft:</para>
+<para>This appendix summarizes the changes introduced in XProc 3.1.</para>
 
-<orderedlist>
-<listitem>
-<para>Allow the output of the <tag>p:insert</tag> step to be <literal>text</literal>.
-(issue
-<link xlink:href="https://github.com/xproc/3.0-steps/issues/583">583</link>.)
-</para>
-</listitem>
-<listitem>
-<para>Clarified that the manifest has precedence in the <tag>p:archive</tag> step.
-(issue
-<link xlink:href="https://github.com/xproc/3.0-steps/issues/462">462</link>.)
-</para>
-</listitem>
-<listitem>
-<para>Changed the type of several options from <tag>xs:token</tag> to
-<tag>xs:string</tag>
-(issue
-<link xlink:href="https://github.com/xproc/3.0-steps/issues/490">490</link>.)
-</para>
-</listitem>
-<listitem>
-<para>Changed the type of the <option>parameters</option> option from
-<code>map(xs:string,xs:untypedAtomic+)</code> to
-<code>map(xs:string,xs:anyAtomicType+)</code>.
-(issue
-<link xlink:href="https://github.com/xproc/3.0-steps/issues/491">491</link>.)
-</para>
-</listitem>
-</orderedlist>
+<section>
+<title>Backwards incompatible changes</title>
 
-<para>These are the non-editorial changes made after the February 2020
-“<link xlink:href="https://spec.xproc.org/lastcall-2020-02/head/steps/">last call</link>”
-draft:</para>
+<itemizedlist>
+<listitem>
+<para>Resolved <link xlink:href="https://github.com/xproc/3.0-steps/issues/549">issue 549</link>
+by making the <port>result</port> output port on <tag>p:compare</tag> primary.</para>
+<para>Although this change is technically backwards incompatible, all known implementations of
+XProc 3.0 implemented it this way, so it is unlikely that it will have any significant
+consequences.</para>
+</listitem>
+<listitem>
+<para>Resolved <link xlink:href="https://github.com/xproc/3.0-steps/issues/548">issue 548</link>
+by correcting the Unicode collation URI in <tag>p:text-sort</tag>.</para>
+<para>The value given in XProc 3.0 is incorrect and must be updated. To mitigate
+any consequences of this correction, implementations are encouraged to continue
+to recognize the incorrect value, perhaps with a warning.
+</para>
+</listitem>
+</itemizedlist>
 
- <orderedlist>
-   <listitem>
-    <para>For <tag>p:cast-content-type</tag> the expected result type for casting a 
-    <literal>c:param-set</literal> document to “<literal>application/json</literal>” was
-    specified as <literal>map(xs:QName, xs:string)</literal>. (2020-03-15)</para>
-  </listitem>
-  <listitem>
-    <para>In <tag>p:http-request</tag>, instead of using all document properties (with a few
-      explicit exceptions) as headers, only document properties in the
-      <code>http://www.w3.org/ns/xproc-http</code> namespace will be used. (2020-03-18)</para>
-  </listitem>
-   <listitem>
-     <para><xref linkend="cv.archive-manifest"/>: An attribute
-       <code>c:entry/@content-type</code> was added to the archive manifest, to be filled by the
-       <tag>p:archive-manifest</tag> step. (2020-03-20)</para>
-   </listitem>
-   <listitem>
-     <para>A <option>static-parameters</option> was added to <tag>p:xslt</tag>. (2020-03-23)</para>
-   </listitem>
-   <listitem>
-     <para>The <option>override-content-types</option> option was added to <tag>p:archive-manifest</tag> and <tag>p:unarchive</tag>. (2020-03-30)</para>
-   </listitem>
-   <listitem>
-        <para>Clarified the regular expression matching for <tag>p:text-replace</tag> and
-            <tag>p:unarchive</tag>. Added an error code for invalid regular expressions. (2020-04-02)</para>
-   </listitem>
-   <listitem>
-     <para>Replaced errors XC0070 and XC0130 with XD0079. (2020-04-09)</para>
-   </listitem>
-   <listitem>
-     <para>Changed signature of <tag>p:split-sequence</tag> so that any document can appear one port 
-       source. (2020-05-22)</para>
-   </listitem>
-   <listitem>
-     <para>Change the behavior of the <option>global-context-item</option> option of <tag>p:xslt</tag>. (2020-06-10)</para>
-   </listitem>
-   <listitem>
-     <para>Clarified which steps may produce PSVI annotations. (2020-06-09)</para>
-   </listitem>
-   <listitem>
-     <para>Clarified the behaviour in <tag>p:archive</tag>: A missing resource referenced by
-     c:archive/c:entry/@href is only an error for command = 'create'. (2020-06-11)</para>
-   </listitem>
-   <listitem>
-     <para>Option <option>populate-default-collection</option> is added to the signature of <tag>p:xslt</tag>. (2020-06-20)</para>
-   </listitem>
-   <listitem>
-     <para>Clarified how the default <literal>content-type</literal> header of <tag>p:http-request</tag> is 
-     constructed if a single document appears on <port>source</port> port. (2020-06-20)</para>
-   </listitem>
-   <listitem>
-     <para>Added error (XD0079) to <tag>p:http-request</tag> and <tag>p:load</tag> for invalid content-types. (2020-06-23)</para>
-   </listitem>
-   <listitem>
-     <para>Changed signature of the <port>result</port> port of <tag>p:load</tag> to <literal>sequence="false"</literal> and
-       adapted the prose accordingly. (2020-06-24)</para>
-   </listitem>
- </orderedlist>
+<section>
+<title>Substantive changes</title>
+  
+<itemizedlist>
+<listitem>
+<para>Resolved <link xlink:href="https://github.com/xproc/3.0-steps/issues/574">issue 574</link>
+by adding a <tag>p:sleep</tag> step.
+</para>
+</listitem>
+<listitem>
+<para>Resolved <link xlink:href="https://github.com/xproc/Vnext/issues/39">V.next issue 29</link> by
+allowing the text documents on the <port>insertion</port> port of the <tag>p:insert</tag> step.
+</para>
+</listitem>
+</itemizedlist>
+</section>
+
+<section>
+<title>Editorial changes</title>
+  
+<itemizedlist>
+<listitem>
+<para>Resolved <link xlink:href="https://github.com/xproc/3.0-steps/issues/580">issue 580</link>
+by clarifying what standards apply to the <option>lang</option> option on <tag>p:text-sort</tag>.
+</para>
+</listitem>
+<listitem>
+<para>Resolved <link xlink:href="https://github.com/xproc/3.0-steps/issues/566">issue 566</link>
+by clarifying when a text document is produced from the
+<tag>p:hash</tag>, <tag>p:replace</tag>, <tag>p:string-replace</tag>, and
+<tag>p:uuid</tag> steps.</para>
+</listitem>
+<listitem>
+<para>Resolved <link xlink:href="https://github.com/xproc/3.0-steps/issues/563">issue 563</link>
+by clarifying that <code>p:set-attributes</code> cannot add “namespace attributes” to an element.
+</para>
+</listitem>
+<listitem>
+<para>Resolved <link xlink:href="https://github.com/xproc/3.0-steps/issues/562">issue 562</link>
+by <link linkend="archive-parameters">clarifying</link> that some parameters are defined for
+ZIP archives.</para>
+</listitem>
+<listitem>
+<para>Resolved <link xlink:href="https://github.com/xproc/3.0-steps/issues/561">issue 561</link>
+and <link xlink:href="https://github.com/xproc/3.0-steps/issues/564">issue 564</link>
+by clarifying in the <tag>p:archive</tag> and <tag>p:archive-manifest</tag> steps
+that <code>err:XC0081</code> should be raised when the
+archive format specified differs from the format of the actual archive and
+<code>err:XC0085</code> should be raised when the format of the
+archive cannot be determined or processed.</para>
+</listitem>
+<listitem>
+<para>Resolved <link xlink:href="https://github.com/xproc/3.0-steps/issues/560">issue 560</link>
+by removing <code>err:XC0118</code> in the <tag>p:archive</tag> step. (It was a duplicate
+of <code>err:XC0100</code>.)</para>
+</listitem>
+<listitem>
+<para>Resolved <link xlink:href="https://github.com/xproc/3.0-steps/issues/559">issue 559</link>
+by clarifying that <code>err:XC0023</code> in <tag>p:rename</tag> applies
+if the match pattern matches more than attribute on a single element.</para>
+</listitem>
+</itemizedlist>
+</section>
+</section>
 </appendix>
 
 </specification>

--- a/steps/src/main/xml/specification.xml
+++ b/steps/src/main/xml/specification.xml
@@ -84,7 +84,9 @@ An XML Pipeline Language</link> published by the W3C.</para>
   <title>Introduction</title>
 
 <para>This specification describes the standard, required atomic XProc
-steps. A machine-readable description of these steps may be found in
+steps. Changes made since the 3.0 specification was published are listed in
+<xref linkend="changelog"/>.
+A machine-readable description of these steps may be found in
 <link xlink:href="steps.xpl">steps.xpl</link>.
 </para>
 
@@ -306,6 +308,11 @@ to recognize the incorrect value, perhaps with a warning.
 <title>Substantive changes</title>
   
 <itemizedlist>
+<listitem>
+<para>Resolved <link xlink:href="https://github.com/xproc/3.0-steps/issues/587">issue 587</link>
+by adding a <option>parameters</option> option to the <tag>p:uuid</tag> step.
+</para>
+</listitem>
 <listitem>
 <para>Resolved <link xlink:href="https://github.com/xproc/3.0-steps/issues/574">issue 574</link>
 by adding a <tag>p:sleep</tag> step.

--- a/steps/src/main/xml/specification.xml
+++ b/steps/src/main/xml/specification.xml
@@ -77,6 +77,9 @@ A “last call” working draft is anticipated shortly.
 <para>This document is derived from
 <link xlink:href="https://www.w3.org/TR/2010/REC-xproc-20100511/">XProc:
 An XML Pipeline Language</link> published by the W3C.</para>
+
+<para>Changes made since the 3.0 specification was published are listed in
+<xref linkend="changelog"/>.</para>
 </legalnotice>
 </info>
 
@@ -84,8 +87,7 @@ An XML Pipeline Language</link> published by the W3C.</para>
   <title>Introduction</title>
 
 <para>This specification describes the standard, required atomic XProc
-steps. Changes made since the 3.0 specification was published are listed in
-<xref linkend="changelog"/>.
+steps.
 A machine-readable description of these steps may be found in
 <link xlink:href="steps.xpl">steps.xpl</link>.
 </para>

--- a/steps/src/main/xml/steps/archive.xml
+++ b/steps/src/main/xml/steps/archive.xml
@@ -108,7 +108,7 @@
           supported.</impl></para>
       </listitem>
     </varlistentry>
-    <varlistentry>
+    <varlistentry xml:id="archive-parameters">
       <term><option>parameters</option></term>
       <listitem>
         <para>The <option>parameters</option> option can be used to supply parameters to control the

--- a/steps/src/main/xml/steps/compare.xml
+++ b/steps/src/main/xml/steps/compare.xml
@@ -53,11 +53,4 @@ summary of the differences between the two documents may appear on the
 <para feature="compare-preserves-none">No document properties are preserved.
 The comparison document has no <property>base-uri</property>.</para>
 </simplesect>
-
-<simplesect>
-<title>Erratum, April 2024</title>
-<para>The <port>result</port> output port has been made primary. This
-is consistent with the behavior of all known implementations.</para>
-</simplesect>
-
 </section>

--- a/steps/src/main/xml/steps/text-sort.xml
+++ b/steps/src/main/xml/steps/text-sort.xml
@@ -84,13 +84,4 @@ newline (&amp;#10;).</para>
     <title>Document properties</title>
     <para feature="text-sort-preserves-all">All document properties are preserved.</para>
   </simplesect>
-
-<simplesect>
-<title>Erratum, April 2024</title>
-<para>The URI for the Unicode Codepoint Collation has been corrected to an <code>http:</code> URI rather than
-an <code>https:</code> one. The URI is an identifier and the correct identifier uses an <code>http:</code> URI.
-Implementations are encouraged to recognized collation URIs that begin with “<code>https://www.w3.org/</code>”
-and treat them as if they began “<code>http://www.w3.org/</code>”, with a warning, if practical.</para>
-</simplesect>
-
 </section>


### PR DESCRIPTION
1. Update the publication metadata for 3.1
2. Replace the changelog with "changes since 3.0"
3. Removed the erratum sections added when we were considering doing a 3.0 with errata publication

