### PR TITLE
Restructuring the step summaries

### DIFF
--- a/src/main/resources/css/xproc.css
+++ b/src/main/resources/css/xproc.css
@@ -184,3 +184,108 @@ sup.xrefspec a:visited {
 
 .assert {
 }
+
+/* ============================================================ */
+
+:root {
+    --tableaux-border-color: #aaaaaa;
+}
+
+div.declare-step {
+    padding-left: 1rem;
+    padding-right: 1rem;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    border: 1px solid var(--tableaux-border-color);
+}
+
+div.declare-step > p {
+    padding: 0;
+    margin: 0;
+    padding-bottom: 0.25rem;
+    font-weight: bold;
+    font-size: 110%;
+}
+
+table.tableaux {
+    width: 100%;
+    margin-bottom: 1rem;
+    border-spacing: 0;
+    border-collapse: separate;
+}
+
+table.tableaux thead th {
+    font-weight: normal;
+}
+
+table.tableaux thead th,
+table.tableaux tbody td {
+    border-right: 1px solid var(--tableaux-border-color);
+}
+
+table.tableaux thead th.port {
+    width: 20%;
+}
+
+table.tableaux thead th.check {
+    width: 10%;
+}
+
+table.tableaux tbody td.check {
+    width: 10%;
+    text-align: center;
+    font-family: serif;
+    font-size: 90%;
+}
+
+table.tableaux thead th.binding {
+    width: 20%;
+}
+
+table.tableaux tbody td.errcode {
+    line-height: 1.5;
+    vertical-align: top;
+}
+
+table.tableaux tbody td.description {
+    font-family: sans-serif;
+    font-size: 100%;
+    line-height: 1.5;
+}
+
+table.tableaux tbody td.primary,
+table.tableaux tbody td.required {
+    font-weight: bold;
+}
+
+table.tableaux thead tr th:first-of-type,
+table.tableaux tbody tr td:first-of-type {
+    border-left: 1px solid var(--tableaux-border-color);
+}
+
+table.tableaux thead th,
+table.tableaux tbody td {
+    padding: 0.25em;
+}
+
+table.tableaux tbody td {
+    font-family: monospace;
+    font-size: 125%;
+}
+
+table.tableaux thead tr:nth-child(1) th,
+table.tableaux tbody tr:nth-child(1) td {
+    border-top: 1px solid var(--tableaux-border-color);
+}
+
+table.tableaux tbody tr:last-of-type td {
+    border-bottom: 1px solid var(--tableaux-border-color);
+}
+
+table.tableaux thead tr th {
+    background-color: #eeeeee;
+}
+
+table.tableaux tbody tr:nth-child(even) td {
+    background-color: #eeeeee;
+}

--- a/tools/xsl/dbspec.xsl
+++ b/tools/xsl/dbspec.xsl
@@ -888,4 +888,14 @@
   </xsl:choose>
 </xsl:template>
 
+<xsl:template match="db:varlistentry/db:term/db:option">
+  <a id="{ancestor::db:section[1]/@xml:id}-def-{.}"/>
+  <xsl:next-match/>
+</xsl:template>
+
+<xsl:template match="db:varlistentry/db:term/db:port">
+  <a id="{ancestor::db:section[1]/@xml:id}-def-{.}"/>
+  <xsl:next-match/>
+</xsl:template>
+
 </xsl:stylesheet>

--- a/tools/xsl/dbspec.xsl
+++ b/tools/xsl/dbspec.xsl
@@ -14,7 +14,7 @@
                 xmlns:xlink="http://www.w3.org/1999/xlink"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 exclude-result-prefixes="f h db doc m ml n rng t xlink xs tmpl"
-                version="2.0">
+                version="3.0">
 
 <xsl:import href="docbook.xsl"/>
 <xsl:import href="ml-macro.xsl"/>

--- a/tools/xsl/dbspec.xsl
+++ b/tools/xsl/dbspec.xsl
@@ -195,11 +195,18 @@
 </xsl:template>
 
 <xsl:template match="db:error">
+  <a>
+    <xsl:attribute name="id">
+      <xsl:apply-templates select="." mode="m:inline-error-anchor"/>
+    </xsl:attribute>
+  </a>
+  <xsl:apply-templates/>
+</xsl:template>
+
+<xsl:template match="db:error" mode="m:inline-error-anchor" expand-text="yes">
   <xsl:variable name="code" select="@code"/>
   <xsl:variable name="num" select="count(preceding::db:error[@code=$code])"/>
-
-  <a id="err.inline.{@code}{if ($num&gt;0) then concat('.',$num) else ''}"/>
-  <xsl:apply-templates/>
+ <xsl:text>err.inline.{@code}{if ($num&gt;0) then concat('.',$num) else ''}"</xsl:text>
 </xsl:template>
 
 <xsl:template match="db:impl">
@@ -236,6 +243,8 @@
 </xsl:template>
   
 <xsl:template match="db:port">
+  <xsl:variable name="name" select="string(.)"/>
+  <a id="port.inline.{.}-{count(preceding::db:port[. = $name])+1}"/>
   <xsl:call-template name="t:inline-monoseq"/>
 </xsl:template>
 
@@ -886,6 +895,12 @@
       <xsl:text>]</xsl:text>
     </xsl:otherwise>
   </xsl:choose>
+</xsl:template>
+
+<xsl:template match="db:option">
+  <xsl:variable name="name" select="string(.)"/>
+  <a id="opt.inline.{.}-{count(preceding::db:option[. = $name])+1}"/>
+  <xsl:call-template name="t:inline-monoseq"/>
 </xsl:template>
 
 <xsl:template match="db:varlistentry/db:term/db:option">

--- a/tools/xsl/docbook.xsl
+++ b/tools/xsl/docbook.xsl
@@ -11,7 +11,7 @@
 		xmlns:xlink="http://www.w3.org/1999/xlink"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
 		exclude-result-prefixes="f h db m mp t xlink xs tp"
-                version="2.0">
+                version="3.0">
 
 <xsl:import href="https://cdn.docbook.org/release/xsl20/current/xslt/base/html/final-pass.xsl"/>
 

--- a/tools/xsl/elemsyntax.xsl
+++ b/tools/xsl/elemsyntax.xsl
@@ -4,7 +4,7 @@
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
 		xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
 		exclude-result-prefixes="e xs"
-                version="2.0">
+                version="3.0">
 
 <xsl:strip-space elements="e:*"/>
 

--- a/tools/xsl/library-to-rnc.xsl
+++ b/tools/xsl/library-to-rnc.xsl
@@ -3,7 +3,7 @@
 		xmlns:p="http://www.w3.org/ns/xproc"
 		xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
 		xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                version="2.0">
+                version="3.0">
 
 <!-- WTF!? Why am I generating the RNC form instead of the RNG form? -->
 

--- a/tools/xsl/make-library.xsl
+++ b/tools/xsl/make-library.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
 		exclude-result-prefixes="xs"
-                version="2.0">
+                version="3.0">
 <!-- N.B. This stylesheet completely ignores its input document. -->
 
 <xsl:param name="libraries" required="yes" as="xs:string"/>

--- a/tools/xsl/make-rng.xsl
+++ b/tools/xsl/make-rng.xsl
@@ -3,7 +3,7 @@
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:rng="http://relaxng.org/ns/structure/1.0"
 		exclude-result-prefixes="xs rng"
-                version="2.0">
+                version="3.0">
 
 <xsl:param name="libraries" required="yes" as="xs:string"/>
 

--- a/tools/xsl/makeglossary.xsl
+++ b/tools/xsl/makeglossary.xsl
@@ -4,7 +4,7 @@
 		xmlns:db="http://docbook.org/ns/docbook"
 		xmlns="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xs"
-                version="2.0">
+                version="3.0">
 
 <xsl:key name="glossterm" match="db:glossterm"
 	 use="if (@baseform) then @baseform else normalize-space(.)"/>

--- a/tools/xsl/masterbib.xsl
+++ b/tools/xsl/masterbib.xsl
@@ -3,7 +3,7 @@
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:db="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xs db"
-                version="2.0">
+                version="3.0">
 
 <xsl:variable name="bib" select="doc('../../src/main/xml/bibliography.xml')"/>
 

--- a/tools/xsl/ml-macro.xsl
+++ b/tools/xsl/ml-macro.xsl
@@ -4,7 +4,7 @@
 		xmlns:xdt="http://www.w3.org/2005/xpath-datatypes"
 		xmlns:xs="http://www.w3.org/2001/XMLSchema"
 		exclude-result-prefixes="ml xdt xs"
-                version="2.0">
+                version="3.0">
 
 <rdf:Description rdf:about=''
 		 xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'

--- a/tools/xsl/pipeline-library.xsl
+++ b/tools/xsl/pipeline-library.xsl
@@ -3,7 +3,7 @@
 		xmlns:p="http://www.w3.org/ns/xproc"
 		xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
 		exclude-result-prefixes="e"
-		version="2.0">
+		version="3.0">
 
 <xsl:output method="xml" indent="yes"/>
 

--- a/tools/xsl/post-pdf.xsl
+++ b/tools/xsl/post-pdf.xsl
@@ -4,7 +4,7 @@
                 xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:html="http://www.w3.org/1999/xhtml"
 		exclude-result-prefixes="xs html"
-                version="2.0">
+                version="3.0">
 
 <xsl:template match="element()">
   <xsl:copy>

--- a/tools/xsl/rngsyntax.xsl
+++ b/tools/xsl/rngsyntax.xsl
@@ -8,7 +8,7 @@
                 xmlns:rng="http://relaxng.org/ns/structure/1.0"
                 xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
                 exclude-result-prefixes="sa xs e rng ss f"
-                version="2.0">
+                version="3.0">
 
 <xsl:strip-space elements="rng:*"/>
 

--- a/tools/xsl/xproc-pdf.xsl
+++ b/tools/xsl/xproc-pdf.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns="http://www.w3.org/1999/xhtml"
-                version="2.0">
+                version="3.0">
 
 <xsl:import href="xproc-specs.xsl"/>
 

--- a/tools/xsl/xproc-specs.xsl
+++ b/tools/xsl/xproc-specs.xsl
@@ -13,7 +13,7 @@
                 xmlns:xlink="http://www.w3.org/1999/xlink"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 exclude-result-prefixes="f h db doc m ml n rng t xlink xs"
-                version="2.0">
+                version="3.0">
 
 <xsl:import href="dbspec.xsl"/>
 

--- a/tools/xsl/xprocns.xsl
+++ b/tools/xsl/xprocns.xsl
@@ -1,5 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns="http://www.w3.org/1999/xhtml" xmlns:db="http://docbook.org/ns/docbook" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:p="http://www.w3.org/ns/xproc" exclude-result-prefixes="p xs db" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:db="http://docbook.org/ns/docbook"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:p="http://www.w3.org/ns/xproc" 
+                exclude-result-prefixes="#all"
+                version="3.0">
 
 <xsl:strip-space elements="p:*"/>
 

--- a/tools/xsl/xprocns.xsl
+++ b/tools/xsl/xprocns.xsl
@@ -7,6 +7,8 @@
                 exclude-result-prefixes="#all"
                 version="3.0">
 
+<xsl:import href="xprocns2.xsl"/>
+
 <xsl:strip-space elements="p:*"/>
 
 <!--
@@ -15,6 +17,17 @@
   <p:output port="result" sequence="yes"/>   
 </p:declare-step>
 -->
+
+<xsl:template match="p:declare-step" priority="100">
+  <div class="declare-step">
+    <p>Summary</p>
+    <xsl:apply-templates select="." mode="alternate-xprocns"/>
+    <details>
+      <summary>Declaration</summary>
+      <xsl:next-match/>
+    </details>
+  </div>
+</xsl:template>
 
 <xsl:template match="p:declare-step">
   <p>

--- a/tools/xsl/xprocns2.xsl
+++ b/tools/xsl/xprocns2.xsl
@@ -2,6 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 		xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
                 xmlns:db="http://docbook.org/ns/docbook"
+                xmlns:m="http://docbook.org/xslt/ns/mode"
                 xmlns:p="http://www.w3.org/ns/xproc" 
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns="http://www.w3.org/1999/xhtml"
@@ -115,7 +116,16 @@
           <xsl:for-each-group select="..//db:error" group-by="@code">
             <xsl:sort select="@code"/>
             <tr>
-              <td class="errcode">err:{current-group()[1]/@code/string()}</td>
+              <td class="errcode">
+                <a>
+                  <xsl:attribute name="href">
+                    <xsl:text>#</xsl:text>
+                    <xsl:apply-templates select="current-group()[1]"
+                                         mode="m:inline-error-anchor"/>
+                  </xsl:attribute>
+                  <xsl:text>err:{current-group()[1]/@code/string()}</xsl:text>
+                </a>
+              </td>
               <td class="description"><xsl:apply-templates select="current-group()[1]"/></td>
             </tr>
           </xsl:for-each-group>
@@ -128,9 +138,23 @@
     <details>
       <summary>Implementation details</summary>
       <table class="tableaux">
+        <thead>
+          <tr>
+            <th>Implementation</th>
+            <th>Description</th>
+          </tr>
+        </thead>
         <tbody>
           <xsl:for-each select="..//db:impl">
             <tr>
+              <td>
+                <a href="#impl-{count(preceding::db:impl)+1}">
+                  <xsl:choose>
+                    <xsl:when test="db:glossterm[. = 'implementation-defined']">Defined</xsl:when>
+                    <xsl:otherwise>Dependent</xsl:otherwise>
+                  </xsl:choose>
+                </a>
+              </td>
               <td class="description"><xsl:apply-templates select="."/></td>
             </tr>
           </xsl:for-each>
@@ -161,7 +185,13 @@
         <xsl:when test="../../db:variablelist/db:varlistentry/db:term/db:port[. = $port]">
           <a href="#{ancestor::db:section[1]/@xml:id}-def-{$port}">{$port}</a>
         </xsl:when>
-        <xsl:otherwise>{$port}</xsl:otherwise>
+        <xsl:when test="../following::db:port[. = $port]">
+          <xsl:variable name="first" select="(../following::db:port[. = $port])[1]"/>
+          <a href="#port.inline.{$port}-{count($first/preceding::db:port[. = $port])+1}">{$port}</a>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:text>{$port}</xsl:text>
+        </xsl:otherwise>
       </xsl:choose>
     </td>
     <td class="check">
@@ -211,6 +241,10 @@
       <xsl:choose>
         <xsl:when test="../../db:variablelist/db:varlistentry/db:term/db:option[. = $name]">
           <a href="#{ancestor::db:section[1]/@xml:id}-def-{$name}">{$name}</a>
+        </xsl:when>
+        <xsl:when test="../following::db:option[. = $name]">
+          <xsl:variable name="first" select="(../following::db:option[. = $name])[1]"/>
+          <a href="#opt.inline.{$name}-{count($first/preceding::db:option[. = $name])+1}">{$name}</a>
         </xsl:when>
         <xsl:otherwise>{$name}</xsl:otherwise>
       </xsl:choose>

--- a/tools/xsl/xprocns2.xsl
+++ b/tools/xsl/xprocns2.xsl
@@ -1,0 +1,242 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+		xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+                xmlns:db="http://docbook.org/ns/docbook"
+                xmlns:p="http://www.w3.org/ns/xproc" 
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns="http://www.w3.org/1999/xhtml"
+                exclude-result-prefixes="#all"
+                default-mode="alternate-xprocns"
+                expand-text="yes"
+                version="3.0">
+
+<xsl:strip-space elements="p:*"/>
+
+<xsl:template match="p:declare-step">
+  <xsl:if test="p:input">
+    <xsl:variable name="columns" as="xs:integer"
+                  select="4
+                          + (if (p:input/@select or p:output/@select) then 1 else 0)
+                          + (if (p:input/* or p:output/*) then 1 else 0)"/>
+    <table class="tableaux">
+      <thead>
+        <tr>
+          <th class="port">Input port</th>
+          <th class="check">Primary</th>
+          <th class="check">Sequence</th>
+          <th>Content types</th>
+          <xsl:if test="p:input/@select or p:output/@select">
+            <th>Default selection</th>
+          </xsl:if>
+          <xsl:if test="p:input/* or p:output/*">
+            <th class="binding">Default binding</th>
+          </xsl:if>
+        </tr>
+      </thead>
+      <tbody>
+        <xsl:apply-templates select="p:input"/>
+      </tbody>
+    </table>
+  </xsl:if>
+
+  <xsl:if test="p:output">
+    <xsl:variable name="columns" as="xs:integer"
+                  select="4
+                          + (if (p:input/@select or p:output/@select) then 1 else 0)
+                          + (if (p:input/* or p:output/*) then 1 else 0)"/>
+    <table class="tableaux">
+      <thead>
+        <tr>
+          <th class="port">Output port</th>
+          <th class="check">Primary</th>
+          <th class="check">Sequence</th>
+          <th>Content types</th>
+          <xsl:if test="p:input/@select or p:output/@select">
+            <th>Default selection</th>
+          </xsl:if>
+          <xsl:if test="p:input/* or p:output/*">
+            <th class="binding">Default binding</th>
+          </xsl:if>
+        </tr>
+      </thead>
+      <tbody>
+        <xsl:apply-templates select="p:output"/>
+      </tbody>
+    </table>
+  </xsl:if>
+
+  <xsl:if test="p:option">
+    <xsl:variable name="columns" as="xs:integer"
+                  select="2
+                          + (if (p:option/@values) then 1 else 0)
+                          + (if (p:option/@static) then 1 else 0)
+                          + (if (p:option/@required) then 1 else 0)"/>
+    <table class="tableaux">
+      <thead>
+        <tr>
+          <th>Option name</th>
+          <th>Type</th>
+          <xsl:if test="p:option/@values">
+            <th>Values</th>
+          </xsl:if>
+          <xsl:if test="exists(p:option[not(@required)])">
+            <th>Default value</th>
+          </xsl:if>
+          <xsl:if test="p:option/@static">
+            <th>Static</th>
+          </xsl:if>
+          <xsl:if test="p:option/@required">
+            <th>Required</th>
+          </xsl:if>
+        </tr>
+      </thead>
+      <tbody>
+        <xsl:apply-templates select="p:option[@required='true']">
+          <xsl:sort select="@name"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="p:option[not(@required='true')]">
+          <xsl:sort select="@name"/>
+        </xsl:apply-templates>
+      </tbody>
+    </table>
+  </xsl:if>
+
+  <xsl:if test="..//db:error">
+    <details>
+      <summary>Errors</summary>
+      <table class="tableaux">
+        <thead>
+          <tr>
+            <th>Error code</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <xsl:for-each-group select="..//db:error" group-by="@code">
+            <xsl:sort select="@code"/>
+            <tr>
+              <td class="errcode">err:{current-group()[1]/@code/string()}</td>
+              <td class="description"><xsl:apply-templates select="current-group()[1]"/></td>
+            </tr>
+          </xsl:for-each-group>
+        </tbody>
+      </table>
+    </details>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template match="p:input|p:output">
+  <xsl:if test="exists(@* except (@port|@primary|@sequence|@select|@content-types))">
+    <xsl:message terminate="yes" select="'Unexpected attributes:', @* ! node-name(.)"/>
+  </xsl:if>
+
+  <xsl:variable name="primary"
+                select="@primary = 'true'
+                        or (self::p:input and count(../p:input) = 1 and not(@primary='false'))
+                        or (self::p:output and count(../p:output) = 1 and not(@primary='false'))"/>
+
+  <tr>
+    <td>
+      <xsl:variable name="port" select="string(@port)"/>
+      <xsl:if test="$primary">
+        <xsl:attribute name="class" select="'primary'"/>
+      </xsl:if>
+
+      <xsl:choose>
+        <xsl:when test="../../db:variablelist/db:varlistentry/db:term/db:port[. = $port]">
+          <a href="#{ancestor::db:section[1]/@xml:id}-def-{$port}">{$port}</a>
+        </xsl:when>
+        <xsl:otherwise>{$port}</xsl:otherwise>
+      </xsl:choose>
+    </td>
+    <td class="check">
+      <xsl:if test="$primary">✔</xsl:if>
+      <xsl:text> </xsl:text>
+    </td>
+    <td class="check">
+      <xsl:if test="@sequence='true'">✔</xsl:if>
+      <xsl:text> </xsl:text>
+    </td>
+    <td>
+      <xsl:text>{@content-types/string()}</xsl:text>
+      <xsl:text> </xsl:text>
+    </td>
+    <xsl:if test="../p:input/@select or ../p:output/@select">
+      <td>
+        <xsl:text>{@select/string()}</xsl:text>
+        <xsl:text> </xsl:text>
+      </td>
+    </xsl:if>
+    <xsl:if test="../p:input/* or ../p:output/*">
+      <td>
+        <xsl:if test="not(empty(*))">
+          <xsl:if test="exists(* except p:empty)">
+            <xsl:message terminate="yes"
+                         select="'Unexpected default binding:', * ! node-name(.)"/>
+          </xsl:if>
+          <xsl:text>p:empty</xsl:text>
+        </xsl:if>
+      </td>
+    </xsl:if>
+  </tr>
+</xsl:template>
+
+<xsl:template match="p:option">
+  <xsl:if test="exists(@* except (@name|@as|@values|@select|@required|@static|@e:type))">
+    <xsl:message terminate="yes" select="'Unexpected attributes:', @* ! node-name(.)"/>
+  </xsl:if>
+
+  <tr>
+    <td>
+      <xsl:variable name="name" select="string(@name)"/>
+      <xsl:if test="@required='true'">
+        <xsl:attribute name="class" select="'required'"/>
+      </xsl:if>
+
+      <xsl:choose>
+        <xsl:when test="../../db:variablelist/db:varlistentry/db:term/db:option[. = $name]">
+          <a href="#{ancestor::db:section[1]/@xml:id}-def-{$name}">{$name}</a>
+        </xsl:when>
+        <xsl:otherwise>{$name}</xsl:otherwise>
+      </xsl:choose>
+    </td>
+    <td>{(@e:type/string(), @as/string(), "xs:string")[1]}</td>
+    <xsl:if test="../p:option/@values">
+      <td>
+        <xsl:text>{@values/string()}</xsl:text>
+        <xsl:text> </xsl:text>
+      </td>
+    </xsl:if>
+
+    <xsl:if test="exists(../p:option[not(@required)])">
+      <td>
+        <xsl:choose>
+          <xsl:when test="@required"> </xsl:when>
+          <xsl:when test="@select">
+            <xsl:text>{@select/string()}</xsl:text>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:text>()</xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
+      </td>
+    </xsl:if>
+
+    <xsl:if test="../p:option/@static">
+      <td>
+        <xsl:if test="@static='true'">✔</xsl:if>
+        <xsl:text> </xsl:text>
+      </td>
+    </xsl:if>
+    <xsl:if test="../p:option/@required">
+      <td>
+        <xsl:if test="@required='true'">✔</xsl:if>
+        <xsl:text> </xsl:text>
+      </td>
+    </xsl:if>
+  </tr>
+</xsl:template>
+        
+
+
+</xsl:stylesheet>

--- a/tools/xsl/xprocns2.xsl
+++ b/tools/xsl/xprocns2.xsl
@@ -123,6 +123,21 @@
       </table>
     </details>
   </xsl:if>
+
+  <xsl:if test="..//db:impl">
+    <details>
+      <summary>Implementation details</summary>
+      <table class="tableaux">
+        <tbody>
+          <xsl:for-each select="..//db:impl">
+            <tr>
+              <td class="description"><xsl:apply-templates select="."/></td>
+            </tr>
+          </xsl:for-each>
+        </tbody>
+      </table>
+    </details>
+  </xsl:if>
 </xsl:template>
 
 <xsl:template match="p:input|p:output">


### PR DESCRIPTION
I was tinkering with a step last night and got a bee in my bonnet about the style of the step summaries. My first thought was that adding some syntax highlighting would improve things. And I guess maybe it did.

Then this morning, I got distracted by the idea that maybe the whole thing could be improved and made more readable.

So here it is. It's certainly different and...I think...it's an improvement.

One observation: the links from the names of ports and options in the summary to their descriptions only work if the descriptions are formatted as a variable list. The fact that we haven't done that in a lot of places is interesting. 

This relates to @xatapult 's thoughts about refactoring the spec entirely in some future version. But in this case there's no change in the spec, just a change in the presentation.