### PR TITLE
Small editorial change to p:count

### DIFF
--- a/src/main/resources/css/xproc.css
+++ b/src/main/resources/css/xproc.css
@@ -2,6 +2,10 @@ html {
     font-size: 110%;
 }
 
+h4 {
+    margin-top: 2rem;
+}
+
 .editors-draft {
     border: solid 1pt #808080;
     padding: 1em;

--- a/steps/src/main/xml/steps/count.xml
+++ b/steps/src/main/xml/steps/count.xml
@@ -17,9 +17,8 @@ sequence.</para>
 <para>If the <tag feature="p-count-limit" class="attribute">limit</tag> option is specified
 and is greater than zero, the <tag>p:count</tag> step will count at most
 that many documents. This provides a convenient mechanism to discover,
-for example, if a sequence consists of more than 1 document, without
-requiring every single document to be buffered before processing can
-continue.</para>
+for example, if a sequence consists of more than 1 document, without
+requiring every document to be counted.</para>
 
 <simplesect>
 <title>Document properties</title>


### PR DESCRIPTION
I happened, randomly, to notice this sentence in the description of `p:count`:

> This provides a convenient mechanism to discover, for example, if a sequence consists of more than 1 document, without requiring every single document to be buffered before processing can continue.

That reference to buffering and continuing is unjustified. I've changed it to:

> This provides a convenient mechanism to discover, for example, if a sequence consists of more than 1 document, without requiring every document to be counted.

I'm not sure that's exactly true either (my implementation counts them all and then returns `min($count,$limit)`), but I think it's an improvement.