### PR TITLE
Move an implementation note out of the summary

### DIFF
--- a/steps/src/main/xml/steps/http-request.xml
+++ b/steps/src/main/xml/steps/http-request.xml
@@ -10,10 +10,7 @@
 with resources over HTTP or related protocols. Implementations
 <rfc2119>must</rfc2119> support the <literal>http</literal> and
 <literal>https</literal> protocols.
-(Implementors are encouraged to support as many protocols as
-practical. In particular, pipeline authors may attempt to use
-<tag>p:http-request</tag> to load documents with computed URIs using
-the <literal>file:</literal> scheme.)</para>
+</para>
 
 <p:declare-step type="p:http-request">
   <p:input port="source" content-types="any" sequence="true"/>
@@ -28,11 +25,14 @@ the <literal>file:</literal> scheme.)</para>
   <p:option name="assert" as="xs:string" select="'.?status-code lt 400'" />
 </p:declare-step>
 
-<para>The <tag>p:http-request</tag> step performs the HTTP request
-specified by the <option>method</option> option against the URI specified in
-the <option>href</option> option. In simple cases, for example, a GET
-request on an unauthenticated URI, nothing else is necessary to form a
-complete request.</para>
+<para>The <tag>p:http-request</tag> step performs the HTTP request specified by
+the <option>method</option> option against the URI specified in the
+<option>href</option> option. In simple cases, for example, a GET request on an
+unauthenticated URI, nothing else is necessary to form a complete request.
+(Implementors are encouraged to support as many protocols as practical. In
+particular, pipeline authors may attempt to use <tag>p:http-request</tag> to
+load documents with computed URIs using the <literal>file:</literal> scheme.)
+</para>
 
 <para>If the method, for example, POST, supports a body, the request
 body is constructed using the document(s) appearing on the


### PR DESCRIPTION
This is a tiny editorial change. I think it's odd to have the parenthetical note to implementors in the step summary, so I've moved it into one of the other introductory paragraphs. There are no technical changes in this PR.