### PR TITLE
Fixed 1.0 left-over in p:filter

### DIFF
--- a/steps/src/main/xml/steps/filter.xml
+++ b/steps/src/main/xml/steps/filter.xml
@@ -14,7 +14,7 @@ based on a (possibly dynamically constructed) XPath select expression.</para>
   <p:option name="select" required="true" as="xs:string" e:type="XPathExpression"/>
 </p:declare-step>
 
-<para>This step behaves just like an <tag>p:input</tag> with
+<para>This step behaves just like an <tag>p:with-input</tag> with
 a <tag class="attribute">select</tag> expression except that the select
 expression is computed dynamically.</para>
 

--- a/steps/src/main/xml/steps/filter.xml
+++ b/steps/src/main/xml/steps/filter.xml
@@ -14,7 +14,7 @@ based on a (possibly dynamically constructed) XPath select expression.</para>
   <p:option name="select" required="true" as="xs:string" e:type="XPathExpression"/>
 </p:declare-step>
 
-<para>This step behaves just like an <tag>p:with-input</tag> with
+<para>This step behaves just like a <tag>p:with-input</tag> with
 a <tag class="attribute">select</tag> expression except that the select
 expression is computed dynamically.</para>
 


### PR DESCRIPTION
I found a small 1.0 left-over in `p:filter` (mentioning `p:input` instead of `p:with-input`). This should fix it.