### PR TITLE
Editorial mistake in p:load fixed

### DIFF
--- a/steps/src/main/xml/steps/load.xml
+++ b/steps/src/main/xml/steps/load.xml
@@ -15,10 +15,7 @@ result a document specified by an IRI.</para>
   <p:option name="document-properties" as="map(xs:QName, item()*)?"/>
 </p:declare-step>
 
-  <para>If the option is relative, it
-    is made absolute against the base URI of the element on which it is specified
-      (<tag>p:with-option</tag> or the step in case of a syntactic shortcut value). If the
-      <option>href</option> is relative, it is made absolute against the base URI of the element on
+  <para>If the <option>href</option> is relative, it is made absolute against the base URI of the element on
     which it is specified (<tag>p:with-option</tag> or <tag>p:load</tag> in the case of a syntactic
     shortcut value). <error code="D0064">It is a <glossterm>dynamic 
       error</glossterm> if the base URI is not both absolute and valid according to <biblioref


### PR DESCRIPTION
There was an editorial mistake in `p:load`. The first sentence repeated itself. Fixed.