### PR TITLE
Editorial fixes for p:archive

### DIFF
--- a/steps/src/main/xml/steps/archive.xml
+++ b/steps/src/main/xml/steps/archive.xml
@@ -139,9 +139,7 @@
   <itemizedlist>
     <listitem>
       <para>If the <option>format</option> option is specified, this determines the format of the
-        archive. Implementations <rfc2119>must</rfc2119> support the <biblioref linkend="zip"/>
-        format, specified with the value <code>zip</code>. <impl>It is
-            <glossterm>implementation-defined</glossterm> what other formats are supported.</impl>
+        archive.
         <error code="C0081">It is a <glossterm>dynamic error</glossterm> if the format of the
           archive does not match the format as specified in the <option>format</option>
           option.</error></para>
@@ -226,7 +224,7 @@
       </listitem>
       <listitem>
         <para>The <code>level</code> attribute specifies the level of compression. <impl>The default
-            compression method is <glossterm>implementation-defined</glossterm>. </impl>
+            compression level is <glossterm>implementation-defined</glossterm>. </impl>
           <impl>It is <glossterm>implementation-defined</glossterm> what compression levels are
             supported.</impl></para>
       </listitem>


### PR DESCRIPTION
The statements:

> Implementations *must* support the ZIP format, specified with the value `zip`. It is *implementation-defined* what other formats are supported.

appeared twice. In the description of compression level, the implementation defined statement about the *method* was repeated.