### PR TITLE
Fix broken links

### DIFF
--- a/step-run/src/main/xml/specification.xml
+++ b/step-run/src/main/xml/specification.xml
@@ -112,12 +112,19 @@ input explicitly.</para>
 using the inputs and options specified on the <tag>p:run</tag> step by means of the 
 <tag>p:run-input</tag> and <tag>p:run-option</tag> elements, respectively.</para>
 
+<section xml:id="p.run-input">
+<title>Inputs</title>
+
 <para>The <tag>p:run-input</tag> element is a special case of the <tag>p:with-input</tag>
 element for passing inputs to the pipeline being run.</para>
 
 <e:rng-pattern name="RunInput"/>
+</section>
 
-<para>Similarly, the <tag>p:run-option</tag> element is a special case
+<section xml:id="p.run-option">
+<title>Options</title>
+
+<para>The <tag>p:run-option</tag> element is a special case
 of the <tag>p:with-option</tag> element for passing options to the
 pipeline being run.</para>
 
@@ -162,6 +169,7 @@ invocation will fail, for example). Options that are provided by <tag>p:run-opti
     <para><error code="C0207">It is a <glossterm>dynamic error</glossterm>
 if the dynamically executed pipeline implicitly or explicitly declares a primary output port with 
 a different name than implicitly or explicitly specified in the <tag>p:run</tag> invocation.</error></para>
+</section>
 
 <section xml:id="example-run">
 <title>Example</title>

--- a/steps/src/main/xml/steps/cast-content-type.xml
+++ b/steps/src/main/xml/steps/cast-content-type.xml
@@ -104,7 +104,7 @@
      <para>A <tag>c:parameter-set</tag> is a wrapper around zero or more <tag>c:param</tag>
      elements.</para>
 
-     <e:rng-pattern name="VocabParamSet"/>
+     <e:rng-pattern name="VocabParamSet" xml:id="cv.param-set"/>
 
      <para><error code="D0018">It is a <glossterm>dynamic error</glossterm> if
      the parameter list contains any elements other than <tag>c:param</tag>.</error></para>
@@ -116,7 +116,7 @@
      
      <para xml:id="c.param">A <tag>c:param</tag> is a name/value pair with an optional namespace.</para>
 
-     <e:rng-pattern name="VocabParam"/>
+     <e:rng-pattern name="VocabParam" xml:id="cv.param"/>
 
      <para>The <tag class="attribute">name</tag> attribute of the
      <tag>c:param</tag> must have the lexical form of a QName.</para>

--- a/tools/xsl/rngsyntax.xsl
+++ b/tools/xsl/rngsyntax.xsl
@@ -11,6 +11,7 @@
                 version="3.0">
 
 <xsl:strip-space elements="rng:*"/>
+<xsl:variable name="root" select="/"/>
 
 <!-- ============================================================ -->
 
@@ -536,9 +537,18 @@
       </var>
     </xsl:when>
     <xsl:otherwise>
-      <a href="#{$idpfx}{$basename}">
-	<xsl:value-of select="concat($prefix,':',$basename)"/>
-      </a>
+      <xsl:variable name="target" select="$idpfx||$basename"/>
+      <xsl:choose>
+        <xsl:when test="empty(id($target, $root))">
+          <xsl:message select="'Ignoring link to ' || $target || ' which does not exist in this document.'"/>
+	  <xsl:value-of select="concat($prefix,':',$basename)"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <a href="#{$idpfx}{$basename}">
+	    <xsl:value-of select="concat($prefix,':',$basename)"/>
+          </a>
+        </xsl:otherwise>
+      </xsl:choose>
       <xsl:value-of select="@repeat"/>
     </xsl:otherwise>
   </xsl:choose>


### PR DESCRIPTION
This is (mostly) a tooling change, but I also added a bit of markup to `p:cast-content-type` and `p:run` to make the links work.