### PR TITLE
Resolved issue 639: Superfluous PSVI remark removed

### DIFF
--- a/steps/src/main/xml/steps/split-sequence.xml
+++ b/steps/src/main/xml/steps/split-sequence.xml
@@ -52,10 +52,6 @@ practice, if the test expression does not use the
 and ignore the context size.</para>
 </note>
 
-<para>If the implementation supports passing PSVI annotations between
-steps, the <tag>p:split-sequence</tag> step <rfc2119>must</rfc2119> preserve
-any annotations that appear in the input.</para>
-
 <simplesect>
 <title>Document properties</title>
 <para feature="split-sequence-preserves-all">All document properties are preserved.</para>


### PR DESCRIPTION
Removed the superfluous PSVI request for `p:split-sequence` (issue #639)