### PR TITLE
Added the attributes option to p:pack, p:wrap, and p:wrap-sequence

### DIFF
--- a/steps/src/main/xml/specification.xml
+++ b/steps/src/main/xml/specification.xml
@@ -254,8 +254,8 @@ PSVI annotations.</para>
 <xi:include href="steps/uncompress.xml"/>
 <xi:include href="steps/unwrap.xml"/>
 <xi:include href="steps/uuid.xml"/>
-<xi:include href="steps/wrap-sequence.xml"/>
 <xi:include href="steps/wrap.xml"/>
+<xi:include href="steps/wrap-sequence.xml"/>
 <xi:include href="steps/www-form-urldecode.xml"/>
 <xi:include href="steps/www-form-urlencode.xml"/>
 <xi:include href="steps/xinclude.xml"/>

--- a/steps/src/main/xml/steps/pack.xml
+++ b/steps/src/main/xml/steps/pack.xml
@@ -22,11 +22,6 @@ wraps them with a new element node whose QName is the value specified
 in the <option>wrapper</option> option, and writes that element to the
 <port>result</port> port as a document.</para>
 
-<para>If the <option>attributes</option> option is used, a new attribute is
-created on the wrapper element for each entry in the map. The attribute name is
-taken from the entry's key while the attribute value is taken from the string
-value of the entry's value.</para>
-
 <para>If the step reaches the end of one input sequence before the
 other, then it simply wraps each of the remaining documents in the
 longer sequence.</para>
@@ -39,10 +34,31 @@ occur between them may have come from either of the input documents;
 this step does not attempt to distinguish which one.</para>
 </note>
 
+<para>If the <option>attributes</option> option is used, a new attribute is
+created on the wrapper element for each entry in the map. The attribute name is
+taken from the entry's key while the attribute value is taken from the string
+value of the entry's value.</para>
+
+<para>Namespace declarations cannot be added
+with the <option>attributes</option> option.
+<error code="C0059">It is a <glossterm>dynamic error</glossterm> if the name
+of any attribute is “<code>xmlns</code>” or uses the prefix
+“<literal>xmlns</literal>”
+or any other prefix that resolves to the namespace name
+<uri>http://www.w3.org/2000/xmlns/</uri>.</error> However,
+if the attributes taken from the <option>attributes</option> use namespaces,
+prefixes, or prefixes bound to different namespaces, the document produced on the
+<port>result</port> output port will require namespace fixup.</para>
+
+<para>If an attribute named <tag class="attribute">xml:base</tag> is added, the
+base URI of the element <rfc2119>must</rfc2119> also be amended
+accordingly.</para>
+
 <simplesect>
 <title>Document properties</title>
 <para feature="pack-preserves-none">No document properties are preserved.
-The result documents do not have a <property>base-uri</property> property.
+The result documents do not have a <property>base-uri</property> property unless
+one is specified with the <option>attributes</option> option.
 </para>
 </simplesect>
 </section>

--- a/steps/src/main/xml/steps/pack.xml
+++ b/steps/src/main/xml/steps/pack.xml
@@ -13,6 +13,7 @@ fashion.</para>
    <p:input port="alternate" sequence="true" content-types="text xml html"/>
    <p:output port="result" sequence="true" content-types="application/xml"/>
    <p:option name="wrapper" required="true" as="xs:QName"/>
+   <p:option name="attributes" as="map(xs:QName, xs:anyAtomicType)?" />
 </p:declare-step>
 
 <para>The step takes each pair of documents, in order, one from the
@@ -20,6 +21,11 @@ fashion.</para>
 wraps them with a new element node whose QName is the value specified
 in the <option>wrapper</option> option, and writes that element to the
 <port>result</port> port as a document.</para>
+
+<para>If the <option>attributes</option> option is used, a new attribute is
+created on the wrapper element for each entry in the map. The attribute name is
+taken from the entry's key while the attribute value is taken from the string
+value of the entry's value.</para>
 
 <para>If the step reaches the end of one input sequence before the
 other, then it simply wraps each of the remaining documents in the

--- a/steps/src/main/xml/steps/wrap-sequence.xml
+++ b/steps/src/main/xml/steps/wrap-sequence.xml
@@ -14,6 +14,7 @@ documents.</para>
    <p:output port="result" sequence="true" content-types="application/xml"/>
    <p:option name="wrapper" required="true" as="xs:QName"/>
    <p:option name="group-adjacent" as="xs:string?" e:type="XPathExpression"/>
+   <p:option name="attributes" as="map(xs:QName, xs:anyAtomicType)?" />
 </p:declare-step>
 
 <para>The value of the <option>group-adjacent</option> option
@@ -25,6 +26,11 @@ each document in the <port>source</port> sequence inside a new
 document element as sequential siblings. The name of the document
 element is the value specified in the <option>wrapper</option>
 option.</para>
+
+<para>If the <option>attributes</option> option is used, a new attribute is
+created on the wrapper element for each entry in the map. The attribute name is
+taken from the entry's key while the attribute value is taken from the string
+value of the entry's value.</para>
 
 <para>The <option>group-adjacent</option> option can be used to group
 adjacent documents.

--- a/steps/src/main/xml/steps/wrap-sequence.xml
+++ b/steps/src/main/xml/steps/wrap-sequence.xml
@@ -27,11 +27,6 @@ document element as sequential siblings. The name of the document
 element is the value specified in the <option>wrapper</option>
 option.</para>
 
-<para>If the <option>attributes</option> option is used, a new attribute is
-created on the wrapper element for each entry in the map. The attribute name is
-taken from the entry's key while the attribute value is taken from the string
-value of the entry's value.</para>
-
 <para>The <option>group-adjacent</option> option can be used to group
 adjacent documents.
 The XPath context
@@ -48,6 +43,26 @@ adjacent” value, they are wrapped together in a single wrapper
 element.
 Two “group adjacent” values are the same if the
 standard XPath function <code>deep-equal()</code> returns true for them.</para>
+
+<para>If the <option>attributes</option> option is used, a new attribute is
+created on the wrapper element for each entry in the map. The attribute name is
+taken from the entry's key while the attribute value is taken from the string
+value of the entry's value.</para>
+
+<para>Namespace declarations cannot be added
+with the <option>attributes</option> option.
+<error code="C0059">It is a <glossterm>dynamic error</glossterm> if the name
+of any attribute is “<code>xmlns</code>” or uses the prefix
+“<literal>xmlns</literal>”
+or any other prefix that resolves to the namespace name
+<uri>http://www.w3.org/2000/xmlns/</uri>.</error> However,
+if the attributes taken from the <option>attributes</option> use namespaces,
+prefixes, or prefixes bound to different namespaces, the document produced on the
+<port>result</port> output port will require namespace fixup.</para>
+
+<para>If an attribute named <tag class="attribute">xml:base</tag> is added, the
+base URI of the element <rfc2119>must</rfc2119> also be amended
+accordingly.</para>
 
 <simplesect>
 <title>Document properties</title>

--- a/steps/src/main/xml/steps/wrap-sequence.xml
+++ b/steps/src/main/xml/steps/wrap-sequence.xml
@@ -67,7 +67,8 @@ accordingly.</para>
 <simplesect>
 <title>Document properties</title>
 <para feature="wrap-sequence-preserves-none">No document properties are preserved.
-The document produced has no <property>base-uri</property> property.
+The result documents do not have a <property>base-uri</property> property unless
+one is specified with the <option>attributes</option> option.
 </para>
 </simplesect>
 </section>

--- a/steps/src/main/xml/steps/wrap.xml
+++ b/steps/src/main/xml/steps/wrap.xml
@@ -14,6 +14,7 @@
    <p:option name="wrapper" required="true" as="xs:QName"/>
    <p:option name="match" required="true" as="xs:string" e:type="XSLTSelectionPattern"/>
    <p:option name="group-adjacent" as="xs:string?" e:type="XPathExpression"/>
+   <p:option name="attributes" as="map(xs:QName, xs:anyAtomicType)?" />
 </p:declare-step>
 
 <para>The value of the <option>match</option> option
@@ -31,6 +32,11 @@ the result is a new document where the document element is a new
 element node whose QName is the value specified in the
 <option>wrapper</option> option. That new element contains copies of
 all of the children of the original document node.</para>
+
+<para>If the <option>attributes</option> option is used, a new attribute is
+created on the wrapper element for each entry in the map. The attribute name is
+taken from the entry's key while the attribute value is taken from the string
+value of the entry's value.</para>
 
 <para>When the <glossterm>selection pattern</glossterm> does not match the document node,
 every node that matches the specified <option>match</option>

--- a/steps/src/main/xml/steps/wrap.xml
+++ b/steps/src/main/xml/steps/wrap.xml
@@ -33,11 +33,6 @@ element node whose QName is the value specified in the
 <option>wrapper</option> option. That new element contains copies of
 all of the children of the original document node.</para>
 
-<para>If the <option>attributes</option> option is used, a new attribute is
-created on the wrapper element for each entry in the map. The attribute name is
-taken from the entry's key while the attribute value is taken from the string
-value of the entry's value.</para>
-
 <para>When the <glossterm>selection pattern</glossterm> does not match the document node,
 every node that matches the specified <option>match</option>
 pattern is replaced with a new element node whose QName is the value
@@ -60,6 +55,26 @@ standard XPath function <code>deep-equal()</code> returns true for them.</para>
 are siblings and either there are no nodes between them or all
 intervening, non-matching nodes are whitespace text, comment, or processing
 instruction nodes.</para>
+
+<para>If the <option>attributes</option> option is used, a new attribute is
+created on the wrapper element for each entry in the map. The attribute name is
+taken from the entry's key while the attribute value is taken from the string
+value of the entry's value.</para>
+
+<para>Namespace declarations cannot be added
+with the <option>attributes</option> option.
+<error code="C0059">It is a <glossterm>dynamic error</glossterm> if the name
+of any attribute is “<code>xmlns</code>” or uses the prefix
+“<literal>xmlns</literal>”
+or any other prefix that resolves to the namespace name
+<uri>http://www.w3.org/2000/xmlns/</uri>.</error> However,
+if the attributes taken from the <option>attributes</option> use namespaces,
+prefixes, or prefixes bound to different namespaces, the document produced on the
+<port>result</port> output port will require namespace fixup.</para>
+
+<para>If an attribute named <tag class="attribute">xml:base</tag> is added, the
+base URI of the element <rfc2119>must</rfc2119> also be amended
+accordingly.</para>
 
 <simplesect>
 <title>Document properties</title>


### PR DESCRIPTION
Fix #656

Incidentally, changed the order of p:wrap and p:wrap-sequence so that they appear in lexicographic order in the specification.