### PR TITLE
Describe a p:message step

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ task make_etc() {
 
 ["steps", "step-file", "step-os", "step-paged-media",
  "step-run", "step-text", "step-mail", "step-rdf", "step-validation",
- "step-ixml"
+ "step-ixml", "step-message"
  ].each { spec ->
   Task t = task "copy_${spec}_build"(dependsOn: [ "buildspecs" ], type: Copy) {
     from "$spec/build/"
@@ -705,6 +705,59 @@ task step_ixml_xpl(dependsOn: ["step-ixml:library"], type: Copy) {
   include "library.xml"
   rename ("library.xml", "steps.xpl")
 }
+
+// ======================================================================
+// step-message
+
+task step_message(type: DocBookTask,
+               dependsOn: [ "download_xproc_toc",
+                            "steps", "xproc_schemas", "spec_schemas",
+                            "step-message:specification",
+                            "step_message_assets",
+                            "step_message_src", "step_message_xpl" ]) {
+  inputs.files fileTree(dir: "tools/xsl/")
+  inputs.files fileTree(dir: "tools/xpl/")
+  inputs.file "build/xproc/toc.xml"
+  input("source", "step-message/build/source.xml")
+  output("result", "build/dist/message/index.html")
+
+  param("schemaext.schema", file("build/schema/dbspec.rng"))
+  param("ci", getenv("CIWORKFLOW"))
+  param("ci-commit", getenv("CI_SHA1"))
+  param("ci-build-number", getenv("CI_BUILD_NUM"))
+  param("ci-user", getenv("CI_PROJECT_USERNAME"))
+  param("ci-repo", getenv("CI_PROJECT_REPONAME"))
+  param("ci-branch", getenv("CI_BRANCH"))
+  param("ci-tag", getenv("CI_TAG"))
+
+  option("style", file("tools/xsl/xproc-specs.xsl"))
+  option("diff", '')
+  option("specid", "message")
+  option("diffloc", buildAbsDir + "/message/diff.html")
+
+  pipeline "tools/xpl/formatspec.xpl"
+}
+buildspecs.dependsOn "step_message"
+
+task step_message_assets(type: Copy) {
+  from "src/main/resources"
+  into "build/dist/message/"
+}
+
+task step_message_src(dependsOn: ["step-message:source"], type: Copy) {
+  from "step-message/build/"
+  into "build/dist/message/"
+  include "source.xml"
+  rename ("source.xml", "specification.xml")
+}
+
+task step_message_xpl(dependsOn: ["step-message:library"], type: Copy) {
+  from "step-message/build/"
+  into "build/dist/message/"
+  include "library.xml"
+  rename ("library.xml", "steps.xpl")
+}
+
 
 // ======================================================================
 // Clean up

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 include 'steps', 'step-validation', 'step-os', 'step-paged-media', 'step-run',
-        'step-file', 'step-text', 'step-mail', 'step-ixml'
+        'step-file', 'step-text', 'step-mail', 'step-ixml', 'step-message'

--- a/step-message/build.gradle
+++ b/step-message/build.gradle
@@ -1,0 +1,95 @@
+repositories {
+  mavenLocal()
+  mavenCentral()
+}
+
+configurations {
+  tools {
+    description = "Run tools"
+    transitive = true
+  }
+}
+
+dependencies {
+  tools (
+    [group: 'org.relaxng', name: 'jing', version: '20181204'],
+    [group: 'org.relaxng', name: 'trang', version: '20181204']
+  )
+}
+
+defaultTasks 'specification'
+
+apply plugin: 'com.xmlcalabash.task'
+
+import com.xmlcalabash.XMLCalabashTask
+import com.nwalsh.tasks.StripAmblesTask
+
+task xinclude(dependsOn: [":spec_schemas"], type: XMLCalabashTask) {
+  inputs.files fileTree(dir: "src/main/xml/")
+  outputs.file "build/xinclude.xml"
+  input("source", "src/main/xml/specification.xml")
+  output("result", "build/xinclude.xml")
+  pipeline "../tools/xpl/validate.xpl"
+}
+xinclude.doFirst {
+  mkdir("build")
+}
+
+task source(dependsOn: ["glossary"], type: XMLCalabashTask) {
+  inputs.file "../tools/xsl/masterbib.xsl"
+  inputs.file "../src/main/xml/bibliography.xml"
+  inputs.file "src/main/xml/specification.xml"
+  inputs.file "build/glossary.xml"
+  outputs.file "build/source.xml"
+  input("source", "src/main/xml/specification.xml")
+  output("result", "build/source.xml")
+  pipeline "../tools/xpl/validate.xpl"
+}
+
+task glossary(dependsOn: ["xinclude"], type: XMLCalabashTask) {
+  inputs.file "build/xinclude.xml"
+  inputs.file "../tools/xpl/makeglossary.xpl"
+  inputs.file "../tools/xsl/makeglossary.xsl"
+  outputs.file "build/glossary.xml"
+  input("source", "build/xinclude.xml")
+  output("result", "build/glossary.xml")
+  pipeline "../tools/xpl/makeglossary.xpl"
+}
+
+task library(dependsOn: ["source"], type: XMLCalabashTask) {
+  inputs.file "build/source.xml"
+  inputs.file "../tools/xpl/typed-pipeline-library.xpl"
+  inputs.file "../tools/xsl/typed-pipeline-library.xsl"
+  outputs.file "build/library.xml"
+  input("source", "build/source.xml")
+  output("result", "build/library.xml")
+  pipeline "../tools/xpl/typed-pipeline-library.xpl"
+}
+
+task rnc(dependsOn: ["library"], type: XMLCalabashTask) {
+  inputs.file "build/library.xml"
+  inputs.file "../tools/xpl/library-to-rnc.xpl"
+  inputs.file "../tools/xsl/library-to-rnc.xsl"
+  outputs.file "build/steps.rnc"
+  input("source", "build/library.xml")
+  output("result", "build/steps.rnc")
+  pipeline "../tools/xpl/library-to-rnc.xpl"
+}
+
+task rng(dependsOn: ["rnc"], type: JavaExec) {
+  inputs.file "build/steps.rnc"
+  outputs.file "build/steps.rng"
+  classpath = configurations.tools
+  mainClass = 'com.thaiopensource.relaxng.translate.Driver'
+  args = ["build/steps.rnc", "build/steps.rng"]
+}
+
+task specification(dependsOn: [ "source", "library", "rng" ]) {
+  // nop
+}
+
+task clean() {
+  doFirst {
+    delete("build")
+  }
+}

--- a/step-message/build/glossary.xml
+++ b/step-message/build/glossary.xml
@@ -1,0 +1,9 @@
+<appendix xmlns:db="http://docbook.org/ns/docbook" xmlns="http://docbook.org/ns/docbook" xml:id="glossary"><title>Glossary</title><glosslist><glossentry><glossterm>implementation-defined</glossterm><glossdef><para>An
+<firstterm>implementation-defined</firstterm> feature is one where the
+implementation has discretion in how it is performed.
+Conformant implementations <rfc2119>must</rfc2119> document
+how <glossterm role="unwrapped">implementation-defined</glossterm> features are performed.</para></glossdef></glossentry><glossentry><glossterm>implementation-dependent</glossterm><glossdef><para>An
+<firstterm>implementation-dependent</firstterm> feature is one where the
+implementation has discretion in how it is performed.
+Implementations are not required to document or explain
+how <glossterm role="unwrapped">implementation-dependent</glossterm> features are performed.</para></glossdef></glossentry></glosslist></appendix>

--- a/step-message/build/library.xml
+++ b/step-message/build/library.xml
@@ -1,0 +1,10 @@
+<p:library xmlns:p="http://www.w3.org/ns/xproc"
+           xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+           version="3.1">
+   <p:declare-step type="p:message" xml:id="message">
+      <p:input port="source" sequence="true"/>
+      <p:output port="result" sequence="true"/>
+      <p:option name="test" as="xs:boolean" select="true()"/>
+      <p:option name="select" as="xs:string"/>
+   </p:declare-step>
+</p:library>

--- a/step-message/build/source.xml
+++ b/step-message/build/source.xml
@@ -1,0 +1,242 @@
+<specification xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="step-mail" class="ed" role="step" version="5.0-extension w3c-xproc">
+  <info>
+    <title>XProc 3.1: message step</title>
+    <!-- defaults to date formatted <pubdate>2014-12-18</pubdate> -->
+<copyright><year>2025</year>
+<holder>the Contributors to the XProc 3.1 Standard Step Library
+specifications</holder>
+</copyright>
+
+<bibliomisc role="github-repo">xproc/3.0-steps</bibliomisc>
+<bibliomisc role="w3c-cg" xlink:href="https://www.w3.org/community/xproc-next/">XProc Next</bibliomisc>
+
+    <bibliorelation type="isformatof" xlink:href="specification.xml">XML</bibliorelation>
+    <authorgroup>
+      <author>
+        <personname>Norman Walsh</personname>
+      </author>
+      <author>
+        <personname>Achim Berndzen</personname>
+      </author>
+      <author>
+        <personname>Gerrit Imsieke</personname>
+      </author>
+      <author>
+        <personname>Erik Siegel</personname>
+      </author>
+    </authorgroup>
+
+    <abstract>
+      <para>This specification describes an optional message step for
+<citetitle>XProc 3.1: An XML Pipeline Language</citetitle>.</para>
+    </abstract>
+
+<legalnotice xml:id="sotd" role="status">
+  <para>This specification was published by the
+  <link xlink:href="https://www.w3.org/community/xproc-next/">XProc
+  Next Community Group</link>. It is not a W3C Standard nor is it on
+  the W3C Standards Track. Please note that under the
+  <link xlink:href="https://www.w3.org/community/about/agreements/cla/">W3C
+  Community Contributor License Agreement (CLA)</link> there is a limited
+  opt-out and other conditions apply. Learn more about <link xlink:href="https://www.w3.org/community/">W3C Community and Business
+  Groups</link>.
+  </para>
+  
+  <para>If you wish to make comments regarding this document, please
+  send them to
+  <link xlink:href="mailto:xproc-dev@w3.org">xproc-dev@w3.org</link>.
+  (<link xlink:href="mailto:xproc-dev-request@w3.org?subject=subscribe">subscribe</link>,
+  <link xlink:href="https://lists.w3.org/Archives/Public/xproc-dev/">archives</link>).
+  </para>
+
+<note role="editorial">
+<para>This draft is the “editor’s working draft” and may continue to evolve.
+</para>
+</note>
+</legalnotice>
+  </info>
+
+  <section xml:id="introduction">
+    <title>Introduction</title>
+
+    <para>This specification describes an optional message step for XProc 3.1.
+A machine-readable description of this step may be found in
+<link xlink:href="steps.xpl">steps.xpl</link>. </para>
+
+<para>Familarity with the general nature of
+<biblioref linkend="xproc31"/> steps is assumed.</para>
+</section>
+
+<section xml:id="library">
+<title>Step library</title>
+
+<section xml:id="c.message">
+<title>p:message</title>
+
+<para>The <code>p:message</code> step conditionally produces a message.</para>
+
+<p:declare-step type="p:message">
+  <p:input port="source" sequence="true"/>
+  <p:output port="result" sequence="true"/>
+  <p:option name="test" as="xs:boolean" select="true()"/>
+  <p:option name="select" as="xs:string"/>
+</p:declare-step>
+
+<para>Steps that produce messages offer one way for an author to keep track of
+the progress of a pipeline. The <tag class="attribute">[p:]message</tag>
+attribute can be added to any step to display a message when it runs.</para>
+
+<para>Status and debugging messages that are appropriate during pipeline
+development may be distracting when the pipeline is running “in production”.
+Existing mechanisms for conditional compilation can be used to mediate between
+“development” and “production” runs, but they are a bit heavyweight. Adding many
+steps with <tag class="attribute">[p:]use-when</tag> attributes and managing the
+connections between steps that may be conditionally removed can make pipelines
+harder to read and understand.</para>
+
+<para>The <tag>p:message</tag> step can be used to achieve much the same effect
+and is considerably less verbose.</para>
+
+<para>If the <tag class="attribute">test</tag> attribute is
+“<literal>true</literal>”, the <tag class="attribute">select</tag> expression is
+evaluated and made available. (As with the <link xlink:href="https://spec.xproc.org/master/head/xproc/#messages">message
+attribute</link>, this is intentionally vague. <impl>Precisely what “made
+available” means is <glossterm>implementation-defined</glossterm>.</impl>
+Often it means “printed on the console”.)</para>
+
+<para>Irrespective of the value of the <tag class="attribute">test</tag>
+attribute, the <tag>p:message</tag> passes all of the documents that appear on
+its <port>source</port> port through to the <port>result</port> port,
+unchanged and in the same order.</para>
+
+<para>If exactly one document appears on the <port>source</port> port, it is the
+context item when the <tag class="attribute">test</tag> and <tag class="attribute">select</tag> expressions are evaluated. In all other cases,
+the context item is undefined.</para>
+
+<para><impl>
+If the <tag class="attribute">test</tag> expression is “<literal>false</literal>”,
+it is <glossterm>implementation-dependent</glossterm> if the
+<tag class="attribute">select</tag> expression is evaluated.</impl>
+</para>
+
+<note>
+<para>If it can be determined statically that <tag class="attribute">test</tag> expression is
+<emphasis>always</emphasis> “<literal>false</literal>”, the processor may remove the 
+step from the pipeline entirely, although it must guarantee that all of the connections
+are preserved.</para>
+</note>
+
+<simplesect>
+  <title>Document properties</title>
+  <para feature="message-preserves-all">All document properties are preserved.</para>
+</simplesect>
+</section>
+</section>
+
+<!--
+  <section xmlns="http://docbook.org/ns/docbook" xml:id="errors">
+    <title>Step Errors</title>
+
+    <para>These steps can raise <glossterm baseform="dynamic-error">dynamic errors</glossterm>. </para>
+
+    <para><termdef xml:id="dt-dynamic-error">A <firstterm>dynamic error</firstterm> is one which occurs while a pipeline
+        is being evaluated.</termdef> Examples of dynamic errors include references to URIs that cannot be resolved,
+      steps which fail, and pipelines that exhaust the capacity of an implementation (such as memory or disk space). For
+      a more complete discussion of dynamic errors, see <xspecref spec="xproc" xref="dynamic-errors"/>. </para>
+
+    <para>If a step fails due to a dynamic error, failure propagates upwards until either a <tag>p:try</tag> is
+      encountered or the entire pipeline fails. In other words, outside of a <tag>p:try</tag>, step failure causes the
+      entire pipeline to fail.</para>
+
+    <para>The following errors can be raised by this step:</para>
+
+    <?step-error-list level="none"?>
+
+  </section>
+-->
+
+<appendix xml:id="conformance">
+<title>Conformance</title>
+
+<para>Conformant processors <rfc2119>must</rfc2119> implement all of the features
+described in this specification except those that are explicitly identified
+as optional.</para>
+
+<para>Some aspects of processor behavior are not completely specified; those
+features are either <glossterm role="unwrapped">implementation-dependent</glossterm> or
+<glossterm role="unwrapped">implementation-defined</glossterm>.</para>
+
+<para><termdef xml:id="dt-implementation-dependent">An
+<firstterm>implementation-dependent</firstterm> feature is one where the
+implementation has discretion in how it is performed.
+Implementations are not required to document or explain
+how <glossterm role="unwrapped">implementation-dependent</glossterm> features are performed.</termdef>
+</para>
+
+<para><termdef xml:id="dt-implementation-defined">An
+<firstterm>implementation-defined</firstterm> feature is one where the
+implementation has discretion in how it is performed.
+Conformant implementations <rfc2119>must</rfc2119> document
+how <glossterm role="unwrapped">implementation-defined</glossterm> features are performed.</termdef>
+</para>
+
+<section xml:id="implementation-defined">
+<title>Implementation-defined features</title>
+
+<para>The following features are implementation-defined:</para>
+
+<?implementation-defined-features?>
+</section>
+
+<section xml:id="implementation-dependent">
+<title>Implementation-dependent features</title>
+
+<para>The following features are implementation-dependent:</para>
+
+<?implementation-dependent-features?>
+</section>
+
+</appendix>
+
+  <appendix xml:id="references">
+    <title>References</title>
+    <bibliolist>
+      <bibliomixed xml:id="xproc31"><abbrev>XProc 3.1</abbrev>
+<citetitle xlink:href="https://spec.xproc.org/lastcall-2024-08/head/xproc/">XProc 3.1:
+An XML Pipeline Language</citetitle>.
+Norman Walsh, Achim Berndzen, Gerrit Imsieke and Erik Siegel, editors.
+</bibliomixed>
+    </bibliolist>
+  </appendix>
+
+  <!-- This glossary will automatically be elided if there are no
+     terms marked up as 'firstterm's in this specification. -->
+  <appendix xmlns:db="http://docbook.org/ns/docbook" xml:id="glossary"><title>Glossary</title><glosslist><glossentry><glossterm>implementation-defined</glossterm><glossdef><para>An
+<firstterm>implementation-defined</firstterm> feature is one where the
+implementation has discretion in how it is performed.
+Conformant implementations <rfc2119>must</rfc2119> document
+how <glossterm role="unwrapped">implementation-defined</glossterm> features are performed.</para></glossdef></glossentry><glossentry><glossterm>implementation-dependent</glossterm><glossdef><para>An
+<firstterm>implementation-dependent</firstterm> feature is one where the
+implementation has discretion in how it is performed.
+Implementations are not required to document or explain
+how <glossterm role="unwrapped">implementation-dependent</glossterm> features are performed.</para></glossdef></glossentry></glosslist></appendix>
+
+  <appendix version="5.0-extension w3c-xproc" xml:id="ancillary-files">
+<title>Ancillary files</title>
+
+<para>This specification includes by reference a number of
+ancillary files.</para>
+
+<variablelist>
+<varlistentry>
+<term><link xlink:href="steps.xpl"/></term>
+<listitem>
+<para>An XProc step library for the declared steps.
+</para>
+</listitem>
+</varlistentry>
+</variablelist>
+
+</appendix>
+
+</specification>

--- a/step-message/build/steps.rnc
+++ b/step-message/build/steps.rnc
@@ -1,0 +1,18 @@
+default namespace p = "http://www.w3.org/ns/xproc"
+namespace local = ""
+
+# This schema could be made more constrained.
+
+Step = Step-message
+
+Step-message =
+  element message {
+    name.ncname.attr?,
+    common.attributes,
+    use-when.attr?,
+    step.attributes,
+    attribute test { avt.datatype }?,
+    attribute select { avt.datatype }?,
+    (WithInput* & WithOption* & (Documentation|PipeInfo)*)
+  }
+

--- a/step-message/build/steps.rng
+++ b/step-message/build/steps.rng
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar ns="http://www.w3.org/ns/xproc" xmlns="http://relaxng.org/ns/structure/1.0">
+  <!-- This schema could be made more constrained. -->
+  <define name="Step">
+    <ref name="Step-message"/>
+  </define>
+  <define name="Step-message">
+    <element name="message">
+      <optional>
+        <ref name="name.ncname.attr"/>
+      </optional>
+      <ref name="common.attributes"/>
+      <optional>
+        <ref name="use-when.attr"/>
+      </optional>
+      <ref name="step.attributes"/>
+      <optional>
+        <attribute name="test">
+          <ref name="avt.datatype"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="select">
+          <ref name="avt.datatype"/>
+        </attribute>
+      </optional>
+      <interleave>
+        <zeroOrMore>
+          <ref name="WithInput"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="WithOption"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <choice>
+            <ref name="Documentation"/>
+            <ref name="PipeInfo"/>
+          </choice>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+</grammar>

--- a/step-message/build/xinclude.xml
+++ b/step-message/build/xinclude.xml
@@ -1,0 +1,242 @@
+<specification xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="step-mail" class="ed" role="step" version="5.0-extension w3c-xproc">
+  <info>
+    <title>XProc 3.1: message step</title>
+    <!-- defaults to date formatted <pubdate>2014-12-18</pubdate> -->
+<copyright><year>2025</year>
+<holder>the Contributors to the XProc 3.1 Standard Step Library
+specifications</holder>
+</copyright>
+
+<bibliomisc role="github-repo">xproc/3.0-steps</bibliomisc>
+<bibliomisc role="w3c-cg" xlink:href="https://www.w3.org/community/xproc-next/">XProc Next</bibliomisc>
+
+    <bibliorelation type="isformatof" xlink:href="specification.xml">XML</bibliorelation>
+    <authorgroup>
+      <author>
+        <personname>Norman Walsh</personname>
+      </author>
+      <author>
+        <personname>Achim Berndzen</personname>
+      </author>
+      <author>
+        <personname>Gerrit Imsieke</personname>
+      </author>
+      <author>
+        <personname>Erik Siegel</personname>
+      </author>
+    </authorgroup>
+
+    <abstract>
+      <para>This specification describes an optional message step for
+<citetitle>XProc 3.1: An XML Pipeline Language</citetitle>.</para>
+    </abstract>
+
+<legalnotice xml:id="sotd" role="status">
+  <para>This specification was published by the
+  <link xlink:href="https://www.w3.org/community/xproc-next/">XProc
+  Next Community Group</link>. It is not a W3C Standard nor is it on
+  the W3C Standards Track. Please note that under the
+  <link xlink:href="https://www.w3.org/community/about/agreements/cla/">W3C
+  Community Contributor License Agreement (CLA)</link> there is a limited
+  opt-out and other conditions apply. Learn more about <link xlink:href="https://www.w3.org/community/">W3C Community and Business
+  Groups</link>.
+  </para>
+  
+  <para>If you wish to make comments regarding this document, please
+  send them to
+  <link xlink:href="mailto:xproc-dev@w3.org">xproc-dev@w3.org</link>.
+  (<link xlink:href="mailto:xproc-dev-request@w3.org?subject=subscribe">subscribe</link>,
+  <link xlink:href="https://lists.w3.org/Archives/Public/xproc-dev/">archives</link>).
+  </para>
+
+<note role="editorial">
+<para>This draft is the “editor’s working draft” and may continue to evolve.
+</para>
+</note>
+</legalnotice>
+  </info>
+
+  <section xml:id="introduction">
+    <title>Introduction</title>
+
+    <para>This specification describes an optional message step for XProc 3.1.
+A machine-readable description of this step may be found in
+<link xlink:href="steps.xpl">steps.xpl</link>. </para>
+
+<para>Familarity with the general nature of
+<biblioref linkend="xproc31"/> steps is assumed.</para>
+</section>
+
+<section xml:id="library">
+<title>Step library</title>
+
+<section xml:id="c.message">
+<title>p:message</title>
+
+<para>The <code>p:message</code> step conditionally produces a message.</para>
+
+<p:declare-step type="p:message">
+  <p:input port="source" sequence="true"/>
+  <p:output port="result" sequence="true"/>
+  <p:option name="test" as="xs:boolean" select="true()"/>
+  <p:option name="select" as="xs:string"/>
+</p:declare-step>
+
+<para>Steps that produce messages offer one way for an author to keep track of
+the progress of a pipeline. The <tag class="attribute">[p:]message</tag>
+attribute can be added to any step to display a message when it runs.</para>
+
+<para>Status and debugging messages that are appropriate during pipeline
+development may be distracting when the pipeline is running “in production”.
+Existing mechanisms for conditional compilation can be used to mediate between
+“development” and “production” runs, but they are a bit heavyweight. Adding many
+steps with <tag class="attribute">[p:]use-when</tag> attributes and managing the
+connections between steps that may be conditionally removed can make pipelines
+harder to read and understand.</para>
+
+<para>The <tag>p:message</tag> step can be used to achieve much the same effect
+and is considerably less verbose.</para>
+
+<para>If the <tag class="attribute">test</tag> attribute is
+“<literal>true</literal>”, the <tag class="attribute">select</tag> expression is
+evaluated and made available. (As with the <link xlink:href="https://spec.xproc.org/master/head/xproc/#messages">message
+attribute</link>, this is intentionally vague. <impl>Precisely what “made
+available” means is <glossterm>implementation-defined</glossterm>.</impl>
+Often it means “printed on the console”.)</para>
+
+<para>Irrespective of the value of the <tag class="attribute">test</tag>
+attribute, the <tag>p:message</tag> passes all of the documents that appear on
+its <port>source</port> port through to the <port>result</port> port,
+unchanged and in the same order.</para>
+
+<para>If exactly one document appears on the <port>source</port> port, it is the
+context item when the <tag class="attribute">test</tag> and <tag class="attribute">select</tag> expressions are evaluated. In all other cases,
+the context item is undefined.</para>
+
+<para><impl>
+If the <tag class="attribute">test</tag> expression is “<literal>false</literal>”,
+it is <glossterm>implementation-dependent</glossterm> if the
+<tag class="attribute">select</tag> expression is evaluated.</impl>
+</para>
+
+<note>
+<para>If it can be determined statically that <tag class="attribute">test</tag> expression is
+<emphasis>always</emphasis> “<literal>false</literal>”, the processor may remove the 
+step from the pipeline entirely, although it must guarantee that all of the connections
+are preserved.</para>
+</note>
+
+<simplesect>
+  <title>Document properties</title>
+  <para feature="message-preserves-all">All document properties are preserved.</para>
+</simplesect>
+</section>
+</section>
+
+<!--
+  <section xmlns="http://docbook.org/ns/docbook" xml:id="errors">
+    <title>Step Errors</title>
+
+    <para>These steps can raise <glossterm baseform="dynamic-error">dynamic errors</glossterm>. </para>
+
+    <para><termdef xml:id="dt-dynamic-error">A <firstterm>dynamic error</firstterm> is one which occurs while a pipeline
+        is being evaluated.</termdef> Examples of dynamic errors include references to URIs that cannot be resolved,
+      steps which fail, and pipelines that exhaust the capacity of an implementation (such as memory or disk space). For
+      a more complete discussion of dynamic errors, see <xspecref spec="xproc" xref="dynamic-errors"/>. </para>
+
+    <para>If a step fails due to a dynamic error, failure propagates upwards until either a <tag>p:try</tag> is
+      encountered or the entire pipeline fails. In other words, outside of a <tag>p:try</tag>, step failure causes the
+      entire pipeline to fail.</para>
+
+    <para>The following errors can be raised by this step:</para>
+
+    <?step-error-list level="none"?>
+
+  </section>
+-->
+
+<appendix xml:id="conformance">
+<title>Conformance</title>
+
+<para>Conformant processors <rfc2119>must</rfc2119> implement all of the features
+described in this specification except those that are explicitly identified
+as optional.</para>
+
+<para>Some aspects of processor behavior are not completely specified; those
+features are either <glossterm role="unwrapped">implementation-dependent</glossterm> or
+<glossterm role="unwrapped">implementation-defined</glossterm>.</para>
+
+<para><termdef xml:id="dt-implementation-dependent">An
+<firstterm>implementation-dependent</firstterm> feature is one where the
+implementation has discretion in how it is performed.
+Implementations are not required to document or explain
+how <glossterm role="unwrapped">implementation-dependent</glossterm> features are performed.</termdef>
+</para>
+
+<para><termdef xml:id="dt-implementation-defined">An
+<firstterm>implementation-defined</firstterm> feature is one where the
+implementation has discretion in how it is performed.
+Conformant implementations <rfc2119>must</rfc2119> document
+how <glossterm role="unwrapped">implementation-defined</glossterm> features are performed.</termdef>
+</para>
+
+<section xml:id="implementation-defined">
+<title>Implementation-defined features</title>
+
+<para>The following features are implementation-defined:</para>
+
+<?implementation-defined-features?>
+</section>
+
+<section xml:id="implementation-dependent">
+<title>Implementation-dependent features</title>
+
+<para>The following features are implementation-dependent:</para>
+
+<?implementation-dependent-features?>
+</section>
+
+</appendix>
+
+  <appendix xml:id="references">
+    <title>References</title>
+    <bibliolist>
+      <bibliomixed xml:id="xproc31"><abbrev>XProc 3.1</abbrev>
+<citetitle xlink:href="https://spec.xproc.org/lastcall-2024-08/head/xproc/">XProc 3.1:
+An XML Pipeline Language</citetitle>.
+Norman Walsh, Achim Berndzen, Gerrit Imsieke and Erik Siegel, editors.
+</bibliomixed>
+    </bibliolist>
+  </appendix>
+
+  <!-- This glossary will automatically be elided if there are no
+     terms marked up as 'firstterm's in this specification. -->
+  <appendix xmlns:db="http://docbook.org/ns/docbook" xml:id="glossary"><title>Glossary</title><glosslist><glossentry><glossterm>implementation-defined</glossterm><glossdef><para>An
+<firstterm>implementation-defined</firstterm> feature is one where the
+implementation has discretion in how it is performed.
+Conformant implementations <rfc2119>must</rfc2119> document
+how <glossterm role="unwrapped">implementation-defined</glossterm> features are performed.</para></glossdef></glossentry><glossentry><glossterm>implementation-dependent</glossterm><glossdef><para>An
+<firstterm>implementation-dependent</firstterm> feature is one where the
+implementation has discretion in how it is performed.
+Implementations are not required to document or explain
+how <glossterm role="unwrapped">implementation-dependent</glossterm> features are performed.</para></glossdef></glossentry></glosslist></appendix>
+
+  <appendix version="5.0-extension w3c-xproc" xml:id="ancillary-files">
+<title>Ancillary files</title>
+
+<para>This specification includes by reference a number of
+ancillary files.</para>
+
+<variablelist>
+<varlistentry>
+<term><link xlink:href="steps.xpl"/></term>
+<listitem>
+<para>An XProc step library for the declared steps.
+</para>
+</listitem>
+</varlistentry>
+</variablelist>
+
+</appendix>
+
+</specification>

--- a/step-message/src/main/xml/ancillary.xml
+++ b/step-message/src/main/xml/ancillary.xml
@@ -1,0 +1,21 @@
+<appendix xmlns="http://docbook.org/ns/docbook"
+	  xmlns:xlink="http://www.w3.org/1999/xlink"
+	  xmlns:xi="http://www.w3.org/2001/XInclude"
+	  version="5.0-extension w3c-xproc"
+	  xml:id="ancillary-files">
+<title>Ancillary files</title>
+
+<para>This specification includes by reference a number of
+ancillary files.</para>
+
+<variablelist>
+<varlistentry>
+<term><link xlink:href="steps.xpl"/></term>
+<listitem>
+<para>An XProc step library for the declared steps.
+</para>
+</listitem>
+</varlistentry>
+</variablelist>
+
+</appendix>

--- a/step-message/src/main/xml/specification.xml
+++ b/step-message/src/main/xml/specification.xml
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<specification xmlns="http://docbook.org/ns/docbook"
+               xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#"
+               xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+               xmlns:p="http://www.w3.org/ns/xproc"
+               xmlns:xi="http://www.w3.org/2001/XInclude"
+               xmlns:xlink="http://www.w3.org/1999/xlink"
+               xml:id="step-mail" class="ed"
+               role="step" version="5.0-extension w3c-xproc">
+  <info>
+    <title>XProc 3.1: message step</title>
+    <!-- defaults to date formatted <pubdate>2014-12-18</pubdate> -->
+<copyright><year>2025</year>
+<holder>the Contributors to the XProc 3.1 Standard Step Library
+specifications</holder>
+</copyright>
+
+<bibliomisc role="github-repo">xproc/3.0-steps</bibliomisc>
+<bibliomisc role="w3c-cg"
+            xlink:href="https://www.w3.org/community/xproc-next/">XProc Next</bibliomisc>
+
+    <bibliorelation type="isformatof" xlink:href="specification.xml">XML</bibliorelation>
+    <authorgroup>
+      <author>
+        <personname>Norman Walsh</personname>
+      </author>
+      <author>
+        <personname>Achim Berndzen</personname>
+      </author>
+      <author>
+        <personname>Gerrit Imsieke</personname>
+      </author>
+      <author>
+        <personname>Erik Siegel</personname>
+      </author>
+    </authorgroup>
+
+    <abstract>
+      <para>This specification describes an optional message step for
+<citetitle>XProc 3.1: An XML Pipeline Language</citetitle>.</para>
+    </abstract>
+
+<legalnotice xml:id="sotd" role="status">
+  <para>This specification was published by the
+  <link xlink:href="https://www.w3.org/community/xproc-next/">XProc
+  Next Community Group</link>. It is not a W3C Standard nor is it on
+  the W3C Standards Track. Please note that under the
+  <link xlink:href="https://www.w3.org/community/about/agreements/cla/">W3C
+  Community Contributor License Agreement (CLA)</link> there is a limited
+  opt-out and other conditions apply. Learn more about <link
+  xlink:href="https://www.w3.org/community/">W3C Community and Business
+  Groups</link>.
+  </para>
+  
+  <para>If you wish to make comments regarding this document, please
+  send them to
+  <link xlink:href="mailto:xproc-dev@w3.org">xproc-dev@w3.org</link>.
+  (<link xlink:href="mailto:xproc-dev-request@w3.org?subject=subscribe">subscribe</link>,
+  <link xlink:href="https://lists.w3.org/Archives/Public/xproc-dev/">archives</link>).
+  </para>
+
+<note role="editorial">
+<para>This draft is the “editor’s working draft” and may continue to evolve.
+</para>
+</note>
+</legalnotice>
+  </info>
+
+  <section xml:id="introduction">
+    <title>Introduction</title>
+
+    <para>This specification describes an optional message step for XProc 3.1.
+A machine-readable description of this step may be found in
+<link xlink:href="steps.xpl">steps.xpl</link>. </para>
+
+<para>Familarity with the general nature of
+<biblioref linkend="xproc31"/> steps is assumed.</para>
+</section>
+
+<section xml:id="library">
+<title>Step library</title>
+
+<section xml:id="c.message">
+<title>p:message</title>
+
+<para>The <code>p:message</code> step conditionally produces a message.</para>
+
+<p:declare-step type="p:message">
+  <p:input port="source" sequence="true"/>
+  <p:output port="result" sequence="true"/>
+  <p:option name="test" as="xs:boolean" select="true()"/>
+  <p:option name="select" as="xs:string"/>
+</p:declare-step>
+
+<para>Steps that produce messages offer one way for an author to keep track of
+the progress of a pipeline. The <tag class="attribute">[p:]message</tag>
+attribute can be added to any step to display a message when it runs.</para>
+
+<para>Status and debugging messages that are appropriate during pipeline
+development may be distracting when the pipeline is running “in production”.
+Existing mechanisms for conditional compilation can be used to mediate between
+“development” and “production” runs, but they are a bit heavyweight. Adding many
+steps with <tag class="attribute">[p:]use-when</tag> attributes and managing the
+connections between steps that may be conditionally removed can make pipelines
+harder to read and understand.</para>
+
+<para>The <tag>p:message</tag> step can be used to achieve much the same effect
+and is considerably less verbose.</para>
+
+<para>If the <tag class="attribute">test</tag> attribute is
+“<literal>true</literal>”, the <tag class="attribute">select</tag> expression is
+evaluated and made available. (As with the <link
+xlink:href="https://spec.xproc.org/master/head/xproc/#messages">message
+attribute</link>, this is intentionally vague. <impl>Precisely what “made
+available” means is <glossterm>implementation-defined</glossterm>.</impl>
+Often it means “printed on the console”.)</para>
+
+<para>Irrespective of the value of the <tag class="attribute">test</tag>
+attribute, the <tag>p:message</tag> passes all of the documents that appear on
+its <port>source</port> port through to the <port>result</port> port,
+unchanged and in the same order.</para>
+
+<para>If exactly one document appears on the <port>source</port> port, it is the
+context item when the <tag class="attribute">test</tag> and <tag
+class="attribute">select</tag> expressions are evaluated. In all other cases,
+the context item is undefined.</para>
+
+<para><impl>
+If the <tag class="attribute">test</tag> expression is “<literal>false</literal>”,
+it is <glossterm>implementation-dependent</glossterm> if the
+<tag class="attribute">select</tag> expression is evaluated.</impl>
+</para>
+
+<note>
+<para>If it can be determined statically that <tag class="attribute">test</tag> expression is
+<emphasis>always</emphasis> “<literal>false</literal>”, the processor may remove the 
+step from the pipeline entirely, although it must guarantee that all of the connections
+are preserved.</para>
+</note>
+
+<simplesect>
+  <title>Document properties</title>
+  <para feature="message-preserves-all">All document properties are preserved.</para>
+</simplesect>
+</section>
+</section>
+
+<!--
+  <section xmlns="http://docbook.org/ns/docbook" xml:id="errors">
+    <title>Step Errors</title>
+
+    <para>These steps can raise <glossterm baseform="dynamic-error">dynamic errors</glossterm>. </para>
+
+    <para><termdef xml:id="dt-dynamic-error">A <firstterm>dynamic error</firstterm> is one which occurs while a pipeline
+        is being evaluated.</termdef> Examples of dynamic errors include references to URIs that cannot be resolved,
+      steps which fail, and pipelines that exhaust the capacity of an implementation (such as memory or disk space). For
+      a more complete discussion of dynamic errors, see <xspecref spec="xproc" xref="dynamic-errors"/>. </para>
+
+    <para>If a step fails due to a dynamic error, failure propagates upwards until either a <tag>p:try</tag> is
+      encountered or the entire pipeline fails. In other words, outside of a <tag>p:try</tag>, step failure causes the
+      entire pipeline to fail.</para>
+
+    <para>The following errors can be raised by this step:</para>
+
+    <?step-error-list level="none"?>
+
+  </section>
+-->
+
+<appendix xmlns="http://docbook.org/ns/docbook"
+	  xml:id="conformance">
+<title>Conformance</title>
+
+<para>Conformant processors <rfc2119>must</rfc2119> implement all of the features
+described in this specification except those that are explicitly identified
+as optional.</para>
+
+<para>Some aspects of processor behavior are not completely specified; those
+features are either <glossterm role='unwrapped'>implementation-dependent</glossterm> or
+<glossterm role='unwrapped'>implementation-defined</glossterm>.</para>
+
+<para><termdef xml:id="dt-implementation-dependent">An
+<firstterm>implementation-dependent</firstterm> feature is one where the
+implementation has discretion in how it is performed.
+Implementations are not required to document or explain
+how <glossterm role='unwrapped'>implementation-dependent</glossterm> features are performed.</termdef>
+</para>
+
+<para><termdef xml:id="dt-implementation-defined">An
+<firstterm>implementation-defined</firstterm> feature is one where the
+implementation has discretion in how it is performed.
+Conformant implementations <rfc2119>must</rfc2119> document
+how <glossterm role='unwrapped'>implementation-defined</glossterm> features are performed.</termdef>
+</para>
+
+<section xml:id="implementation-defined">
+<title>Implementation-defined features</title>
+
+<para>The following features are implementation-defined:</para>
+
+<?implementation-defined-features?>
+</section>
+
+<section xml:id="implementation-dependent">
+<title>Implementation-dependent features</title>
+
+<para>The following features are implementation-dependent:</para>
+
+<?implementation-dependent-features?>
+</section>
+
+</appendix>
+
+  <appendix xml:id="references">
+    <title>References</title>
+    <bibliolist>
+      <bibliomixed xml:id="xproc31"/>
+    </bibliolist>
+  </appendix>
+
+  <!-- This glossary will automatically be elided if there are no
+     terms marked up as 'firstterm's in this specification. -->
+  <xi:include href="../../../build/glossary.xml">
+    <xi:fallback>
+      <glossary xml:id="glossary">
+        <title>Glossary</title>
+        <para>Glossary needs to be generated</para>
+      </glossary>
+    </xi:fallback>
+  </xi:include>
+
+  <xi:include href="ancillary.xml"/>
+
+</specification>


### PR DESCRIPTION
It seems like a consensus is forming to add a `p:message` step, so I took a stab at describing it.

The only open question in my mind is, if the `test` expression is `false()`, is the implementation forbidden from evaluating the select expression or is that implementation-dependent. (Or implementation-defined, I guess.)